### PR TITLE
Print ttt preset to chat feature

### DIFF
--- a/src/TextToTalk/TextToTalk.cs
+++ b/src/TextToTalk/TextToTalk.cs
@@ -99,6 +99,7 @@ namespace TextToTalk
             this.keysDown = false;
         }
 
+        private bool presetKeysDown;
         private void CheckPresetKeybindPressed(Framework framework)
         {
             foreach (var preset in this.config.EnabledChatTypesPresets.Where(p => p.UseKeybind))
@@ -106,9 +107,20 @@ namespace TextToTalk
                 if (this.keys[(byte)preset.ModifierKey] &&
                     this.keys[(byte)preset.MajorKey])
                 {
+                    if (this.presetKeysDown) return;
+
+                    this.presetKeysDown = true;
+
                     this.config.SetCurrentEnabledChatTypesPreset(preset.Id);
+                    var commandModule = this.commandManager.GetCommandModule<MainCommandModule>();
+                    commandModule.Chat.Print($"TextToTalk preset -> {preset.Name}");
+                    PluginLog.Log($"TextToTalk preset -> {preset.Name}");
+
+                    return;
                 }
             }
+
+            this.presetKeysDown = false;
         }
 
         private void PollTalkAddon(Framework framework)

--- a/src/TextToTalk/TextToTalk.cs
+++ b/src/TextToTalk/TextToTalk.cs
@@ -34,7 +34,6 @@ namespace TextToTalk
 
         private readonly PluginConfiguration config;
         private readonly CommandManager commandManager;
-        private readonly MainCommandModule commandModule;
         private readonly Services services;
         private readonly KeyState keys;
 
@@ -76,9 +75,6 @@ namespace TextToTalk
             var commands = this.services.GetService<Dalamud.Game.Command.CommandManager>();
             this.commandManager = new CommandManager(commands, this.services);
             this.commandManager.AddCommandModule<MainCommandModule>();
-
-            this.commandModule = new MainCommandModule();
-            this.commandModule = this.commandManager.GetCommandModule<MainCommandModule>();
         }
 
         private bool keysDown = false;
@@ -102,8 +98,10 @@ namespace TextToTalk
                     if (this.keysDown) return true;
 
                     this.keysDown = true;
+
                     this.config.SetCurrentEnabledChatTypesPreset(preset.Id);
-                    this.commandModule.Chat.Print($"TextToTalk preset -> {preset.Name}");
+                    var commandModule = this.commandManager.GetCommandModule<MainCommandModule>();
+                    commandModule.Chat.Print($"TextToTalk preset -> {preset.Name}");
                     PluginLog.Log($"TextToTalk preset -> {preset.Name}");
                     return true;
                 }
@@ -119,7 +117,9 @@ namespace TextToTalk
                 if (this.keysDown) return true;
 
                 this.keysDown = true;
-                this.commandModule.ToggleTts();
+
+                var commandModule = this.commandManager.GetCommandModule<MainCommandModule>();
+                commandModule.ToggleTts();
                 return true;
             }
             return false;

--- a/src/TextToTalk/TextToTalk.cs
+++ b/src/TextToTalk/TextToTalk.cs
@@ -77,30 +77,25 @@ namespace TextToTalk
             this.commandManager.AddCommandModule<MainCommandModule>();
         }
 
-        private bool keysDown;
+        private bool keysDown = false;
         private void CheckKeybindPressed(Framework framework)
         {
             if (!this.config.UseKeybind) return;
 
-            if (this.keys[(byte)this.config.ModifierKey] &&
-                this.keys[(byte)this.config.MajorKey])
-            {
-                if (this.keysDown) return;
+            if (this.CheckTTSToggleKeybind()) return;
+            if (this.CheckPresetKeybind()) return;
 
-                this.keysDown = true;
+            this.keysDown = false;
+        }
 
-                var commandModule = this.commandManager.GetCommandModule<MainCommandModule>();
-                commandModule.ToggleTts();
-
-                return;
-            }
-
+        private bool CheckPresetKeybind()
+        {
             foreach (var preset in this.config.EnabledChatTypesPresets.Where(p => p.UseKeybind))
             {
                 if (this.keys[(byte)preset.ModifierKey] &&
                     this.keys[(byte)preset.MajorKey])
                 {
-                    if (this.keysDown) return;
+                    if (this.keysDown) return true;
 
                     this.keysDown = true;
 
@@ -108,12 +103,26 @@ namespace TextToTalk
                     var commandModule = this.commandManager.GetCommandModule<MainCommandModule>();
                     commandModule.Chat.Print($"TextToTalk preset -> {preset.Name}");
                     PluginLog.Log($"TextToTalk preset -> {preset.Name}");
-
-                    return;
+                    return true;
                 }
             }
-            
-            this.keysDown = false;
+            return false;
+        }
+
+        private bool CheckTTSToggleKeybind()
+        {
+            if (this.keys[(byte)this.config.ModifierKey] &&
+                this.keys[(byte)this.config.MajorKey])
+            {
+                if (this.keysDown) return true;
+
+                this.keysDown = true;
+
+                var commandModule = this.commandManager.GetCommandModule<MainCommandModule>();
+                commandModule.ToggleTts();
+                return true;
+            }
+            return false;
         }
 
         private void PollTalkAddon(Framework framework)

--- a/src/TextToTalk/TextToTalk.cs
+++ b/src/TextToTalk/TextToTalk.cs
@@ -71,7 +71,6 @@ namespace TextToTalk
             var framework = this.services.GetService<Framework>();
             framework.Update += PollTalkAddon;
             framework.Update += CheckKeybindPressed;
-            framework.Update += CheckPresetKeybindPressed;
 
             var commands = this.services.GetService<Dalamud.Game.Command.CommandManager>();
             this.commandManager = new CommandManager(commands, this.services);
@@ -96,20 +95,14 @@ namespace TextToTalk
                 return;
             }
 
-            this.keysDown = false;
-        }
-
-        private bool presetKeysDown;
-        private void CheckPresetKeybindPressed(Framework framework)
-        {
             foreach (var preset in this.config.EnabledChatTypesPresets.Where(p => p.UseKeybind))
             {
                 if (this.keys[(byte)preset.ModifierKey] &&
                     this.keys[(byte)preset.MajorKey])
                 {
-                    if (this.presetKeysDown) return;
+                    if (this.keysDown) return;
 
-                    this.presetKeysDown = true;
+                    this.keysDown = true;
 
                     this.config.SetCurrentEnabledChatTypesPreset(preset.Id);
                     var commandModule = this.commandManager.GetCommandModule<MainCommandModule>();
@@ -119,8 +112,8 @@ namespace TextToTalk
                     return;
                 }
             }
-
-            this.presetKeysDown = false;
+            
+            this.keysDown = false;
         }
 
         private void PollTalkAddon(Framework framework)
@@ -256,7 +249,6 @@ namespace TextToTalk
             var framework = this.services.GetService<Framework>();
             framework.Update -= PollTalkAddon;
             framework.Update -= CheckKeybindPressed;
-            framework.Update -= CheckPresetKeybindPressed;
 
             var chat = this.services.GetService<ChatGui>();
             chat.ChatMessage -= CheckFailedToBindPort;

--- a/src/TextToTalk/TextToTalk.cs
+++ b/src/TextToTalk/TextToTalk.cs
@@ -34,6 +34,7 @@ namespace TextToTalk
 
         private readonly PluginConfiguration config;
         private readonly CommandManager commandManager;
+        private readonly MainCommandModule commandModule;
         private readonly Services services;
         private readonly KeyState keys;
 
@@ -75,6 +76,9 @@ namespace TextToTalk
             var commands = this.services.GetService<Dalamud.Game.Command.CommandManager>();
             this.commandManager = new CommandManager(commands, this.services);
             this.commandManager.AddCommandModule<MainCommandModule>();
+
+            this.commandModule = new MainCommandModule();
+            this.commandModule = this.commandManager.GetCommandModule<MainCommandModule>();
         }
 
         private bool keysDown = false;
@@ -98,10 +102,8 @@ namespace TextToTalk
                     if (this.keysDown) return true;
 
                     this.keysDown = true;
-
                     this.config.SetCurrentEnabledChatTypesPreset(preset.Id);
-                    var commandModule = this.commandManager.GetCommandModule<MainCommandModule>();
-                    commandModule.Chat.Print($"TextToTalk preset -> {preset.Name}");
+                    this.commandModule.Chat.Print($"TextToTalk preset -> {preset.Name}");
                     PluginLog.Log($"TextToTalk preset -> {preset.Name}");
                     return true;
                 }
@@ -117,9 +119,7 @@ namespace TextToTalk
                 if (this.keysDown) return true;
 
                 this.keysDown = true;
-
-                var commandModule = this.commandManager.GetCommandModule<MainCommandModule>();
-                commandModule.ToggleTts();
+                this.commandModule.ToggleTts();
                 return true;
             }
             return false;


### PR DESCRIPTION
I've implemented issue https://github.com/karashiiro/TextToTalk/issues/55 with this pull request.

The commit, [Add feature - print to chat the name of preset when switching](https://github.com/karashiiro/TextToTalk/commit/615a7edd49bf18d8e233f6e39e72979b68d79950), is fully functional and satisfies all of the goals of issue https://github.com/karashiiro/TextToTalk/issues/55. The other commits are just code refactors.

The commit, [Refactored commandModule object creation into an instance variable](https://github.com/karashiiro/TextToTalk/commit/fbf83ad9fd39523db928520d0f12d9803210616b), is probably the one you'll want to look over and decide whether that's an improvement or not. My guess is that, although it may take more memory to create a `new` MainCommandModule object that persists, it seems like we might improve on performance by not having to repeatedly create new local objects multiple times for each update.