### PR TITLE
Add ability to boost volume to 200% for Polly

### DIFF
--- a/lexicons/Americanize-pronunciations/lexicon.pls
+++ b/lexicons/Americanize-pronunciations/lexicon.pls
@@ -11,4 +11,9 @@
 <grapheme>lieutenant</grapheme>
 <phoneme>luˈtɛn ənt</phoneme>
 </lexeme>
+<lexeme>
+<grapheme>Clerk</grapheme>
+<grapheme>clerk</grapheme>
+<phoneme>klɜrk</phoneme>
+</lexeme>
 </lexicon>

--- a/lexicons/Americanize-pronunciations/package.yml
+++ b/lexicons/Americanize-pronunciations/package.yml
@@ -1,0 +1,6 @@
+name: Americanize UK voice word pronunciations
+author: ryankhart
+disabled: false
+description: An opinionated lexicon for those using UK voices but prefer the US pronunciation for words such as "lieutenant". For example, this forces even UK voices to say "Loo-ten-ant" rather than "Left-ten-ant".
+files:
+  - lexicon.pls

--- a/lexicons/Characters-Locations-Polly/lexicon.pls
+++ b/lexicons/Characters-Locations-Polly/lexicon.pls
@@ -432,6 +432,10 @@
 </lexeme>
 <lexeme>
 <grapheme>Amh Araeng</grapheme>
-<phoneme></phoneme>
+<phoneme>ˈɑːm məˈræŋ</phoneme>
+</lexeme>
+<lexeme>
+<grapheme>Jul</grapheme>
+<phoneme>ˈʝuːəl</phoneme>
 </lexeme>
 </lexicon>

--- a/lexicons/Characters-Locations-System/lexicon.pls
+++ b/lexicons/Characters-Locations-System/lexicon.pls
@@ -432,6 +432,10 @@
 </lexeme>
 <lexeme>
 <grapheme>Amh Araeng</grapheme>
-<phoneme></phoneme>
+<phoneme>ˈɑːm məˈræŋ</phoneme>
+</lexeme>
+<lexeme>
+<grapheme>Jul</grapheme>
+<phoneme>ˈʝuːəl</phoneme>
 </lexeme>
 </lexicon>

--- a/lexicons/Lieutenant-US-Pronunciation/package.yml
+++ b/lexicons/Lieutenant-US-Pronunciation/package.yml
@@ -1,6 +1,0 @@
-name: Lieutenant US Pronunciation
-author: ryankhart
-disabled: false
-description: An opinionated lexicon those using UK voices but prefer the US pronunciation of "lieutenant". This forces even UK voices to say "Loo-ten-ant" rather than "Left-ten-ant".
-files:
-  - lexicon.pls

--- a/lexicons/Unconfirmed-Name-Pronunciations/lexicon.pls
+++ b/lexicons/Unconfirmed-Name-Pronunciations/lexicon.pls
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lexicon version="1.0" 
+      xmlns="http://www.w3.org/2005/01/pronunciation-lexicon"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+      xsi:schemaLocation="http://www.w3.org/2005/01/pronunciation-lexicon 
+        http://www.w3.org/TR/2007/CR-pronunciation-lexicon-20071212/pls.xsd"
+      alphabet="ipa" 
+      xml:lang="en">
+<lexeme>
+<grapheme>An Lad</grapheme>
+<phoneme>ɒn lɒd</phoneme>
+</lexeme>
+</lexicon>

--- a/lexicons/Unconfirmed-Name-Pronunciations/package.yml
+++ b/lexicons/Unconfirmed-Name-Pronunciations/package.yml
@@ -1,0 +1,6 @@
+name: Unconfirmed Name Pronunciations
+author: ryankhart
+disabled: false
+description: A lexicon that includes unconfirmed or speculative pronunciations that have not been heard in voice acting (at least by me yet). Word pronunciations added to this lexicon are based on my own opinion, but if anyone corrects them in the TextToTalk Community Lexicon discussions page, I'd be happy to change it and add it to the main lexicon file instead.
+files:
+  - lexicon.pls

--- a/src/TextToTalk/Backends/Polly/PollyBackendUI.cs
+++ b/src/TextToTalk/Backends/Polly/PollyBackendUI.cs
@@ -135,7 +135,7 @@ public class PollyBackendUI
         }
 
         var volume = (int)(this.config.PollyVolume * 100);
-        if (ImGui.SliderInt("Volume##TTTVoice7", ref volume, 0, 100))
+        if (ImGui.SliderInt("Volume##TTTVoice7", ref volume, 0, 200, "%d%%"))
         {
             this.config.PollyVolume = (float)Math.Round((double)volume / 100, 2);
             this.config.Save();


### PR DESCRIPTION
Also formatted the number in the UI to look like a percent.
I tried this for the System voice backend, and the game crashed, but it seems fine for Amazon Polly backend.

I had been having this issue where the text-to-speech voice volume was so much quieter than not only the game sound but the rest of my Windows volume of other apps. I worked around this by setting my game volume to 30% to make it not completely overpower the volume of text-to-speech, and that worked, but when I am alt-tabbing in and out of the game frequently, I often found myself having to constantly adjust my Windows system or speaker volume because it was so loud coming from the game where I had my volume high to hear the quiet TTS to my browser tabs watching YouTube where the volume frequently startled me from being so loud.

This might not be the most elegant solution what I have committed here, but it seemed the simplest to implement this way, and I also didn't want to keep the max at 100% and then double it after the volume variable was saved because people updating from an older version of TextToTalk would then get blasted with double the volume unexpectedly.