### PR TITLE
Fixes aliases so that text that matches with graphemes get replaced with the lexeme's alias.

### DIFF
--- a/src/TextToTalk.Lexicons/LexiconManager.cs
+++ b/src/TextToTalk.Lexicons/LexiconManager.cs
@@ -69,7 +69,6 @@ namespace TextToTalk.Lexicons
                             Alias = el.Element($"{nsPrefix}alias")?.Value,
                         })
                     )
-                    .Where(lexeme => !string.IsNullOrEmpty(lexeme.Phoneme))
                     .ToList(),
             };
 
@@ -93,12 +92,17 @@ namespace TextToTalk.Lexicons
         {
             foreach (var lexicon in this.lexicons)
             {
-                foreach (var lexeme in lexicon.Lexemes.Where(lexeme => text.Contains(lexeme.Grapheme) || (!string.IsNullOrEmpty(lexeme.Alias) && text.Contains(lexeme.Alias))))
+                foreach (var lexeme in lexicon.Lexemes.Where(lexeme => text.Contains(lexeme.Grapheme)))
                 {
-                    text = WrapGrapheme(text, lexeme.Grapheme, lexeme.Phoneme);
                     if (!string.IsNullOrEmpty(lexeme.Alias))
                     {
-                        text = WrapGrapheme(text, lexeme.Alias, lexeme.Phoneme);
+                        text = text.Replace(lexeme.Grapheme, lexeme.Alias);
+                        break; // Avoid replacing more than once. Many lexemes have more than one grapheme.
+                    }
+
+                    if (!string.IsNullOrEmpty(lexeme.Phoneme))
+                    {
+                        text = WrapGrapheme(text, lexeme.Grapheme, lexeme.Phoneme);
                     }
                 }
             }


### PR DESCRIPTION
Remove requirement for lexemes to have a phoneme.
Add check to see if phoneme exists before attempting to use it.
Remove redundant alias checks.

One thing I couldn't solve was preventing UK Amazon Polly voices from saying "nine inch nails" in place of "nin" because if I replaced "nin" with a "ninja" alias, then words like "nintendo" would be replaced with "ninjatendo". Hilarious, but no thank you. I'll just keep only one grapheme for the "ninja" alias, the all caps one "NIN". I should find out if I can just send Amazon some feedback about my complaints instead of trying to shoehorn this project to workaround it.