### PR TITLE
Add configuration option to disable stutter remover

### DIFF
--- a/src/TextToTalk/PluginConfiguration.cs
+++ b/src/TextToTalk/PluginConfiguration.cs
@@ -110,6 +110,8 @@ namespace TextToTalk
         public float UberduckVolume { get; set; } = 1.0f;
         public int UberduckPlaybackRate { get; set; } = 100;
 
+        public bool RemoveStutterEnabled { get; set; } = true;
+
         public IDictionary<string, IDictionary<TTSBackend, bool>> RemoteLexiconEnabledBackends { get; set; }
 
         public bool UsePlayerRateLimiter { get; set; }

--- a/src/TextToTalk/TextToTalk.cs
+++ b/src/TextToTalk/TextToTalk.cs
@@ -160,27 +160,13 @@ namespace TextToTalk
                 return;
             }
 
-            string cleanText;
-
-            if (config.RemoveStutterEnabled)
-            {
-                cleanText = Pipe(
+            var cleanText = Pipe(
                 textValue,
                 TalkUtils.StripAngleBracketedText,
                 TalkUtils.ReplaceSsmlTokens,
                 TalkUtils.NormalizePunctuation,
-                TalkUtils.RemoveStutters,
+                t => this.config.RemoveStutterEnabled ? TalkUtils.RemoveStutters(t) : t,
                 x => x.Trim());
-            }
-            else
-            {
-                cleanText = Pipe(
-                textValue,
-                TalkUtils.StripAngleBracketedText,
-                TalkUtils.ReplaceSsmlTokens,
-                TalkUtils.NormalizePunctuation,
-                x => x.Trim());
-            }
 
             if (!cleanText.Any() || !TalkUtils.IsSpeakable(cleanText))
             {

--- a/src/TextToTalk/TextToTalk.cs
+++ b/src/TextToTalk/TextToTalk.cs
@@ -160,13 +160,27 @@ namespace TextToTalk
                 return;
             }
 
-            var cleanText = Pipe(
+            string cleanText;
+
+            if (config.RemoveStutterEnabled)
+            {
+                cleanText = Pipe(
                 textValue,
                 TalkUtils.StripAngleBracketedText,
                 TalkUtils.ReplaceSsmlTokens,
                 TalkUtils.NormalizePunctuation,
                 TalkUtils.RemoveStutters,
                 x => x.Trim());
+            }
+            else
+            {
+                cleanText = Pipe(
+                textValue,
+                TalkUtils.StripAngleBracketedText,
+                TalkUtils.ReplaceSsmlTokens,
+                TalkUtils.NormalizePunctuation,
+                x => x.Trim());
+            }
 
             if (!cleanText.Any() || !TalkUtils.IsSpeakable(cleanText))
             {

--- a/src/TextToTalk/UI/Dalamud/ConfigurationWindow.cs
+++ b/src/TextToTalk/UI/Dalamud/ConfigurationWindow.cs
@@ -220,6 +220,16 @@ namespace TextToTalk.UI.Dalamud
                     BackendManager.DrawSettings(this.helpers);
                 }
             }
+
+            if (ImGui.CollapsingHeader("Experimental", ImGuiTreeNodeFlags.DefaultOpen))
+            {
+                var removeStutterEnabled = Configuration.RemoveStutterEnabled;
+                if (ImGui.Checkbox("Attempt to remove stutter from NPC dialogue (default: On)", ref removeStutterEnabled))
+                {
+                    Configuration.RemoveStutterEnabled = removeStutterEnabled;
+                    Configuration.Save();
+                }
+            }
         }
 
         private void DrawChannelSettings()


### PR DESCRIPTION
I'm not proud of the way I did the config.RemoveStutterEnabled conditional.
I couldn't figure out an elegant way to use lamda or a += syntax with the way it's currently set up.
I also tried and failed to read from the PluginConfiguration from inside the TalkUtils.cs but couldn't because its a static class.
I'm interested to see if there's a better way to do this.

This PR is an attempt to provide contributors a testing tool for improving the stutter remover and to provide users a workaround for issues like this one: https://github.com/karashiiro/TextToTalk/issues/86