### PR TITLE
Support multiple voice presets per gender option

### DIFF
--- a/src/TextToTalk.Tests/packages.lock.json
+++ b/src/TextToTalk.Tests/packages.lock.json
@@ -394,6 +394,11 @@
         "resolved": "4.3.0",
         "contentHash": "VB5cn/7OzUfzdnC8tqAIMQciVLiq2epm2NrAm1E9OjNRyG4lVhfR61SMcLizejzQP8R8Uf/0l5qOIbUEi+RdEg=="
       },
+      "Standart.Hash.xxHash": {
+        "type": "Transitive",
+        "resolved": "4.0.5",
+        "contentHash": "2QC9zDPFT/SOnP7iFdK3AwakEcJ7D3zDoU7IwIAOyEhY4WQ2GQBvLqZ29/R1BSujPNtGHMITmVW1d+VjvLg6lg=="
+      },
       "System.AppContext": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -1258,6 +1263,7 @@
           "Dalamud.CrystalTower": "2.0.1",
           "DalamudPackager": "2.1.8",
           "NAudio": "2.1.0",
+          "Standart.Hash.xxHash": "4.0.5",
           "System.Drawing.Common": "6.0.0",
           "System.Speech": "6.0.0",
           "TextToTalk.Lexicons": "1.0.0",

--- a/src/TextToTalk/Backends/BackendUI.cs
+++ b/src/TextToTalk/Backends/BackendUI.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using ImGuiNET;
+
+namespace TextToTalk.Backends;
+
+public static class BackendUI
+{
+    public static readonly Vector4 HintColor = new(0.7f, 0.7f, 0.7f, 1.0f);
+    public static readonly Vector4 Red = new(1, 0, 0, 1);
+    
+    public static void ImGuiVoiceNotSupported()
+    {
+        ImGui.TextColored(Red, "Voice not supported on this engine");
+    }
+    
+    public static bool ImGuiPresetCombo(string label, SortedSet<int> selectedPresets, List<VoicePreset> presets)
+    {
+        var selectedPresetNames =
+            presets.Where(preset => selectedPresets.Contains(preset.Id)).Select(preset => preset.Name);
+        if (!ImGui.BeginCombo(label, string.Join(", ", selectedPresetNames)))
+        {
+            return false;
+        }
+        
+        var didPresetsChange = false;
+        
+        foreach (var preset in presets)
+        {
+            var isPresetSelected = selectedPresets.Contains(preset.Id);
+            if (ImGui.Selectable(preset.Name, ref isPresetSelected, ImGuiSelectableFlags.DontClosePopups))
+            {
+                if (isPresetSelected)
+                {
+                    selectedPresets.Add(preset.Id);
+                }
+                else
+                {
+                    selectedPresets.Remove(preset.Id);
+                }
+                didPresetsChange = true;
+            }
+        }
+        
+        ImGui.EndCombo();
+        return didPresetsChange;
+    }
+}

--- a/src/TextToTalk/Backends/BackendUI.cs
+++ b/src/TextToTalk/Backends/BackendUI.cs
@@ -14,6 +14,11 @@ public static class BackendUI
     {
         ImGui.TextColored(Red, "Voice not supported on this engine");
     }
+
+    public static void ImGuiMultiVoiceHint()
+    {
+        ImGui.TextColored(BackendUI.HintColor, "If multiple presets are selected per gender, they will be randomly assigned to characters.");
+    }
     
     public static bool ImGuiPresetCombo(string label, SortedSet<int> selectedPresets, List<VoicePreset> presets)
     {

--- a/src/TextToTalk/Backends/Polly/PollyBackendUI.cs
+++ b/src/TextToTalk/Backends/Polly/PollyBackendUI.cs
@@ -255,7 +255,7 @@ public class PollyBackendUI
                     this.config.Save();
                 }
 
-                ImGui.TextColored(BackendUI.HintColor, "If multiple presets are selected, they will be randomly assigned to characters.");
+                BackendUI.ImGuiMultiVoiceHint();
             }
         }
     }

--- a/src/TextToTalk/Backends/System/SystemBackend.cs
+++ b/src/TextToTalk/Backends/System/SystemBackend.cs
@@ -48,22 +48,6 @@ namespace TextToTalk.Backends.System
             return this.soundQueue.GetCurrentlySpokenTextSource();
         }
 
-        public VoicePreset GetSystemVoiceForGender(Gender gender)
-        {
-            var voicePreset = this.config.GetCurrentVoicePreset<SystemVoicePreset>();
-            if (this.config.UseGenderedVoicePresets)
-            {
-                voicePreset = gender switch
-                {
-                    Gender.Male => this.config.GetCurrentMaleVoicePreset<SystemVoicePreset>(),
-                    Gender.Female => this.config.GetCurrentFemaleVoicePreset<SystemVoicePreset>(),
-                    _ => this.config.GetCurrentUngenderedVoicePreset<SystemVoicePreset>(),
-                };
-            }
-
-            return voicePreset;
-        }
-
         protected override void Dispose(bool disposing)
         {
             if (disposing)

--- a/src/TextToTalk/Backends/System/SystemBackendUI.cs
+++ b/src/TextToTalk/Backends/System/SystemBackendUI.cs
@@ -180,6 +180,8 @@ public class SystemBackendUI
             {
                 this.config.Save();
             }
+
+            BackendUI.ImGuiMultiVoiceHint();
         }
     }
 

--- a/src/TextToTalk/Backends/System/SystemBackendUI.cs
+++ b/src/TextToTalk/Backends/System/SystemBackendUI.cs
@@ -17,9 +17,6 @@ namespace TextToTalk.Backends.System;
 
 public class SystemBackendUI
 {
-    private static readonly Vector4 Red = new(1, 0, 0, 1);
-    private static readonly Vector4 HintColor = new(0.7f, 0.7f, 0.7f, 1.0f);
-
     private static readonly Lazy<SpeechSynthesizer> DummySynthesizer = new(() =>
     {
         try
@@ -55,7 +52,7 @@ public class SystemBackendUI
 
     public void DrawSettings(IConfigUIDelegates helpers)
     {
-        ImGui.TextColored(HintColor, "This TTS provider is only supported on Windows.");
+        ImGui.TextColored(BackendUI.HintColor, "This TTS provider is only supported on Windows.");
 
         if (this.selectVoiceFailures.TryDequeue(out var e1))
         {
@@ -79,7 +76,7 @@ public class SystemBackendUI
         }
         else
         {
-            ImGui.TextColored(Red, "You have no presets. Please create one using the \"New preset\" button.");
+            ImGui.TextColored(BackendUI.Red, "You have no presets. Please create one using the \"New preset\" button.");
         }
 
         if (ImGui.Button("New preset##TTTSystemVoice4") &&
@@ -98,19 +95,10 @@ public class SystemBackendUI
         {
             var otherPreset = this.config.VoicePresetConfig.VoicePresets.First(p => p.Id != currentVoicePreset.Id);
             this.config.SetCurrentVoicePreset(otherPreset.Id);
-
-            if (this.config.VoicePresetConfig.UngenderedVoicePresets[TTSBackend.System] == currentVoicePreset.Id)
-            {
-                this.config.VoicePresetConfig.UngenderedVoicePresets[TTSBackend.System] = 0;
-            }
-            else if (this.config.VoicePresetConfig.MaleVoicePresets[TTSBackend.System] == currentVoicePreset.Id)
-            {
-                this.config.VoicePresetConfig.MaleVoicePresets[TTSBackend.System] = 0;
-            }
-            else if (this.config.VoicePresetConfig.FemaleVoicePresets[TTSBackend.System] == currentVoicePreset.Id)
-            {
-                this.config.VoicePresetConfig.FemaleVoicePresets[TTSBackend.System] = 0;
-            }
+            
+            this.config.VoicePresetConfig.UngenderedVoicePresets[TTSBackend.System].Remove(currentVoicePreset.Id);
+            this.config.VoicePresetConfig.MaleVoicePresets[TTSBackend.System].Remove(currentVoicePreset.Id);
+            this.config.VoicePresetConfig.FemaleVoicePresets[TTSBackend.System].Remove(currentVoicePreset.Id);
 
             this.config.VoicePresetConfig.VoicePresets.Remove(currentVoicePreset);
         }
@@ -175,30 +163,21 @@ public class SystemBackendUI
 
         if (useGenderedVoicePresets)
         {
-            var currentUngenderedVoicePreset = this.config.GetCurrentUngenderedVoicePreset<SystemVoicePreset>();
-            var currentMaleVoicePreset = this.config.GetCurrentMaleVoicePreset<SystemVoicePreset>();
-            var currentFemaleVoicePreset = this.config.GetCurrentFemaleVoicePreset<SystemVoicePreset>();
-
-            var presetArray = presets.Select(p => p.Name).ToArray();
-
-            var ungenderedPresetIndex = presets.IndexOf(currentUngenderedVoicePreset);
-            if (ImGui.Combo("Ungendered preset##TTTSystemVoice12", ref ungenderedPresetIndex, presetArray, presets.Count))
+            if (BackendUI.ImGuiPresetCombo("Ungendered preset(s)##TTTSystemVoice12",
+                    this.config.VoicePresetConfig.UngenderedVoicePresets[TTSBackend.System], presets))
             {
-                this.config.VoicePresetConfig.UngenderedVoicePresets[TTSBackend.System] = presets[ungenderedPresetIndex].Id;
                 this.config.Save();
             }
 
-            var malePresetIndex = presets.IndexOf(currentMaleVoicePreset);
-            if (ImGui.Combo("Male preset##TTTSystemVoice10", ref malePresetIndex, presetArray, presets.Count))
+            if (BackendUI.ImGuiPresetCombo("Male preset(s)##TTTSystemVoice10",
+                    this.config.VoicePresetConfig.MaleVoicePresets[TTSBackend.System], presets))
             {
-                this.config.VoicePresetConfig.MaleVoicePresets[TTSBackend.System] = presets[malePresetIndex].Id;
                 this.config.Save();
             }
 
-            var femalePresetIndex = presets.IndexOf(currentFemaleVoicePreset);
-            if (ImGui.Combo("Female preset##TTTSystemVoice11", ref femalePresetIndex, presetArray, presets.Count))
+            if (BackendUI.ImGuiPresetCombo("Female preset(s)##TTTSystemVoice11",
+                    this.config.VoicePresetConfig.FemaleVoicePresets[TTSBackend.System], presets))
             {
-                this.config.VoicePresetConfig.FemaleVoicePresets[TTSBackend.System] = presets[femalePresetIndex].Id;
                 this.config.Save();
             }
         }
@@ -208,12 +187,12 @@ public class SystemBackendUI
     {
         if (e.InnerException != null)
         {
-            ImGui.TextColored(Red, $"Voice errors:\n  {e.Message}");
+            ImGui.TextColored(BackendUI.Red, $"Voice errors:\n  {e.Message}");
             PrintVoiceExceptionsR(e.InnerException);
         }
         else
         {
-            ImGui.TextColored(Red, $"Voice error:\n  {e.Message}");
+            ImGui.TextColored(BackendUI.Red, $"Voice error:\n  {e.Message}");
         }
     }
 
@@ -221,7 +200,7 @@ public class SystemBackendUI
     {
         do
         {
-            ImGui.TextColored(Red, $"  {e.Message}");
+            ImGui.TextColored(BackendUI.Red, $"  {e.Message}");
         } while (e.InnerException != null);
     }
 

--- a/src/TextToTalk/Backends/Uberduck/UberduckBackendUI.cs
+++ b/src/TextToTalk/Backends/Uberduck/UberduckBackendUI.cs
@@ -180,6 +180,8 @@ public class UberduckBackendUI
                 {
                     this.config.Save();
                 }
+
+                BackendUI.ImGuiMultiVoiceHint();
             }
         }
     }

--- a/src/TextToTalk/Migrations/Migration1_17.cs
+++ b/src/TextToTalk/Migrations/Migration1_17.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using Amazon.Polly;
 using Dalamud.Logging;
 using TextToTalk.Backends;
@@ -43,10 +44,13 @@ public class Migration1_17 : IConfigurationMigration
                 }
             }
 
-            config.VoicePresetConfig.CurrentVoicePresets[TTSBackend.System] = config.CurrentVoicePresetId;
-            config.VoicePresetConfig.UngenderedVoicePresets[TTSBackend.System] = config.UngenderedVoicePresetId;
-            config.VoicePresetConfig.MaleVoicePresets[TTSBackend.System] = config.MaleVoicePresetId;
-            config.VoicePresetConfig.FemaleVoicePresets[TTSBackend.System] = config.FemaleVoicePresetId;
+            config.VoicePresetConfig.CurrentVoicePreset[TTSBackend.System] = config.CurrentVoicePresetId;
+            config.VoicePresetConfig.UngenderedVoicePresets[TTSBackend.System] =
+                new SortedSet<int> { config.UngenderedVoicePresetId };
+            config.VoicePresetConfig.MaleVoicePresets[TTSBackend.System] =
+                new SortedSet<int> { config.MaleVoicePresetId };
+            config.VoicePresetConfig.FemaleVoicePresets[TTSBackend.System] =
+                new SortedSet<int> { config.FemaleVoicePresetId };
         }
 
         // Migrate Polly voice configuration
@@ -59,8 +63,9 @@ public class Migration1_17 : IConfigurationMigration
                 defaultPreset.VoiceName = config.PollyVoiceUngendered ?? config.PollyVoice ?? VoiceId.Matthew;
                 defaultPreset.PlaybackRate = config.PollyPlaybackRate;
                 defaultPreset.SampleRate = config.PollySampleRate;
-                config.VoicePresetConfig.CurrentVoicePresets[TTSBackend.AmazonPolly] = defaultPreset.Id;
-                config.VoicePresetConfig.UngenderedVoicePresets[TTSBackend.AmazonPolly] = defaultPreset.Id;
+                config.VoicePresetConfig.CurrentVoicePreset[TTSBackend.AmazonPolly] = defaultPreset.Id;
+                config.VoicePresetConfig.UngenderedVoicePresets[TTSBackend.AmazonPolly] =
+                    new SortedSet<int> { defaultPreset.Id };
             }
             
             if (config.UseGenderedVoicePresets && config.TryCreateVoicePreset<PollyVoicePreset>(out var malePreset))
@@ -71,7 +76,8 @@ public class Migration1_17 : IConfigurationMigration
                 malePreset.VoiceName = config.PollyVoiceMale ?? VoiceId.Matthew;
                 malePreset.PlaybackRate = config.PollyPlaybackRate;
                 malePreset.SampleRate = config.PollySampleRate;
-                config.VoicePresetConfig.MaleVoicePresets[TTSBackend.AmazonPolly] = malePreset.Id;
+                config.VoicePresetConfig.MaleVoicePresets[TTSBackend.AmazonPolly] =
+                    new SortedSet<int> { malePreset.Id };
             }
             
             if (config.UseGenderedVoicePresets && config.TryCreateVoicePreset<PollyVoicePreset>(out var femalePreset))
@@ -82,7 +88,8 @@ public class Migration1_17 : IConfigurationMigration
                 femalePreset.VoiceName = config.PollyVoiceFemale ?? VoiceId.Matthew;
                 femalePreset.PlaybackRate = config.PollyPlaybackRate;
                 femalePreset.SampleRate = config.PollySampleRate;
-                config.VoicePresetConfig.FemaleVoicePresets[TTSBackend.AmazonPolly] = femalePreset.Id;
+                config.VoicePresetConfig.FemaleVoicePresets[TTSBackend.AmazonPolly] =
+                    new SortedSet<int> { femalePreset.Id };
             }
         }
         
@@ -94,8 +101,9 @@ public class Migration1_17 : IConfigurationMigration
                 defaultPreset.Volume = config.UberduckVolume;
                 defaultPreset.PlaybackRate = config.UberduckPlaybackRate;
                 defaultPreset.VoiceName = config.UberduckVoiceUngendered ?? config.UberduckVoice ?? "zwf";
-                config.VoicePresetConfig.CurrentVoicePresets[TTSBackend.Uberduck] = defaultPreset.Id;
-                config.VoicePresetConfig.UngenderedVoicePresets[TTSBackend.Uberduck] = defaultPreset.Id;
+                config.VoicePresetConfig.CurrentVoicePreset[TTSBackend.Uberduck] = defaultPreset.Id;
+                config.VoicePresetConfig.UngenderedVoicePresets[TTSBackend.Uberduck] =
+                    new SortedSet<int> { defaultPreset.Id };
             }
             
             if (config.UseGenderedVoicePresets && config.TryCreateVoicePreset<UberduckVoicePreset>(out var malePreset))
@@ -104,7 +112,7 @@ public class Migration1_17 : IConfigurationMigration
                 malePreset.Volume = config.UberduckVolume;
                 malePreset.PlaybackRate = config.UberduckPlaybackRate;
                 malePreset.VoiceName = config.UberduckVoiceMale ?? "zwf";
-                config.VoicePresetConfig.MaleVoicePresets[TTSBackend.Uberduck] = malePreset.Id;
+                config.VoicePresetConfig.MaleVoicePresets[TTSBackend.Uberduck] = new SortedSet<int> { malePreset.Id };
             }
             
             if (config.UseGenderedVoicePresets && config.TryCreateVoicePreset<UberduckVoicePreset>(out var femalePreset))
@@ -113,7 +121,8 @@ public class Migration1_17 : IConfigurationMigration
                 femalePreset.Volume = config.UberduckVolume;
                 femalePreset.PlaybackRate = config.UberduckPlaybackRate;
                 femalePreset.VoiceName = config.UberduckVoiceFemale ?? "zwf";
-                config.VoicePresetConfig.FemaleVoicePresets[TTSBackend.Uberduck] = femalePreset.Id;
+                config.VoicePresetConfig.FemaleVoicePresets[TTSBackend.Uberduck] =
+                    new SortedSet<int> { femalePreset.Id };
             }
         }
         
@@ -122,20 +131,22 @@ public class Migration1_17 : IConfigurationMigration
             if (config.TryCreateVoicePreset<WebsocketVoicePreset>(out var defaultPreset))
             {
                 defaultPreset.Name = "Default";
-                config.VoicePresetConfig.CurrentVoicePresets[TTSBackend.Websocket] = defaultPreset.Id;
-                config.VoicePresetConfig.UngenderedVoicePresets[TTSBackend.Websocket] = defaultPreset.Id;
+                config.VoicePresetConfig.CurrentVoicePreset[TTSBackend.Websocket] = defaultPreset.Id;
+                config.VoicePresetConfig.UngenderedVoicePresets[TTSBackend.Websocket] =
+                    new SortedSet<int> { defaultPreset.Id };
             }
             
             if (config.UseGenderedVoicePresets && config.TryCreateVoicePreset<WebsocketVoicePreset>(out var malePreset))
             {
                 malePreset.Name = "Male";
-                config.VoicePresetConfig.MaleVoicePresets[TTSBackend.Websocket] = malePreset.Id;
+                config.VoicePresetConfig.MaleVoicePresets[TTSBackend.Websocket] = new SortedSet<int> { malePreset.Id };
             }
             
             if (config.UseGenderedVoicePresets && config.TryCreateVoicePreset<WebsocketVoicePreset>(out var femalePreset))
             {
                 femalePreset.Name = "Female";
-                config.VoicePresetConfig.FemaleVoicePresets[TTSBackend.Websocket] = femalePreset.Id;
+                config.VoicePresetConfig.FemaleVoicePresets[TTSBackend.Websocket] =
+                    new SortedSet<int> { femalePreset.Id };
             }
         }
         

--- a/src/TextToTalk/PluginConfiguration.cs
+++ b/src/TextToTalk/PluginConfiguration.cs
@@ -284,38 +284,41 @@ namespace TextToTalk
             return preset;
         }
 
-        public IList<VoicePreset> GetVoicePresetsForBackend(TTSBackend backend)
+        public IEnumerable<VoicePreset> GetVoicePresetsForBackend(TTSBackend backend)
         {
-            return VoicePresetConfig.VoicePresets.Where(p => p.EnabledBackend == backend).ToList();
+            return VoicePresetConfig.VoicePresets.Where(p => p.EnabledBackend == backend);
         }
 
         public void SetCurrentEnabledChatTypesPreset(int presetId)
         {
             CurrentPresetId = presetId;
         }
-
+       
         public TPreset GetCurrentVoicePreset<TPreset>() where TPreset : VoicePreset
         {
             return VoicePresetConfig.VoicePresets.FirstOrDefault(p =>
-                p.Id == VoicePresetConfig.CurrentVoicePresets[Backend] && p.EnabledBackend == Backend) as TPreset;
+                p.Id == VoicePresetConfig.CurrentVoicePreset[Backend] && p.EnabledBackend == Backend) as TPreset;
         }
 
-        public TPreset GetCurrentUngenderedVoicePreset<TPreset>() where TPreset : VoicePreset
+        public TPreset[] GetCurrentUngenderedVoicePresets<TPreset>() where TPreset : VoicePreset
         {
-            return VoicePresetConfig.VoicePresets.FirstOrDefault(p =>
-                p.Id == VoicePresetConfig.UngenderedVoicePresets[Backend] && p.EnabledBackend == Backend) as TPreset;
+            return VoicePresetConfig.VoicePresets.Where(p =>
+                    VoicePresetConfig.UngenderedVoicePresets[Backend].Contains(p.Id) && p.EnabledBackend == Backend)
+                .Cast<TPreset>().ToArray();
         }
 
-        public TPreset GetCurrentMaleVoicePreset<TPreset>() where TPreset : VoicePreset
+        public TPreset[] GetCurrentMaleVoicePresets<TPreset>() where TPreset : VoicePreset
         {
-            return VoicePresetConfig.VoicePresets.FirstOrDefault(p =>
-                p.Id == VoicePresetConfig.MaleVoicePresets[Backend] && p.EnabledBackend == Backend) as TPreset;
+            return VoicePresetConfig.VoicePresets.Where(p =>
+                    VoicePresetConfig.MaleVoicePresets[Backend].Contains(p.Id) && p.EnabledBackend == Backend)
+                .Cast<TPreset>().ToArray();
         }
 
-        public TPreset GetCurrentFemaleVoicePreset<TPreset>() where TPreset : VoicePreset
+        public TPreset[] GetCurrentFemaleVoicePresets<TPreset>() where TPreset : VoicePreset
         {
-            return VoicePresetConfig.VoicePresets.FirstOrDefault(p =>
-                p.Id == VoicePresetConfig.FemaleVoicePresets[Backend] && p.EnabledBackend == Backend) as TPreset;
+            return VoicePresetConfig.VoicePresets.Where(p =>
+                    VoicePresetConfig.FemaleVoicePresets[Backend].Contains(p.Id) && p.EnabledBackend == Backend)
+                .Cast<TPreset>().ToArray();
         }
 
         public int GetHighestVoicePresetId()
@@ -343,7 +346,7 @@ namespace TextToTalk
 
         public void SetCurrentVoicePreset(int presetId)
         {
-            VoicePresetConfig.CurrentVoicePresets[Backend] = presetId;
+            VoicePresetConfig.CurrentVoicePreset[Backend] = presetId;
         }
     }
 }

--- a/src/TextToTalk/TextToTalk.csproj
+++ b/src/TextToTalk/TextToTalk.csproj
@@ -31,6 +31,7 @@
 		<PackageReference Include="DalamudPackager" Version="2.1.8" />
 		<PackageReference Include="log4net" Version="2.0.15" />
 		<PackageReference Include="NAudio" Version="2.1.0" />
+		<PackageReference Include="Standart.Hash.xxHash" Version="4.0.5" />
 		<PackageReference Include="System.Drawing.Common" Version="6.0.0" />
 		<PackageReference Include="System.Speech" Version="6.0.0" />
 	</ItemGroup>

--- a/src/TextToTalk/VoicePresetConfiguration.cs
+++ b/src/TextToTalk/VoicePresetConfiguration.cs
@@ -22,10 +22,10 @@ public class VoicePresetConfiguration
     // also can't be loaded from within the plugin because of restrictions on collectable assemblies.
     [JsonProperty] private IList<IDictionary<string, object>> VoicePresetsRaw { get; set; }
 
-    public IDictionary<TTSBackend, int> CurrentVoicePresets { get; init; }
-    public IDictionary<TTSBackend, int> UngenderedVoicePresets { get; init; }
-    public IDictionary<TTSBackend, int> MaleVoicePresets { get; init; }
-    public IDictionary<TTSBackend, int> FemaleVoicePresets { get; init; }
+    public IDictionary<TTSBackend, int> CurrentVoicePreset { get; init; }
+    public IDictionary<TTSBackend, SortedSet<int>> UngenderedVoicePresets { get; init; }
+    public IDictionary<TTSBackend, SortedSet<int>> MaleVoicePresets { get; init; }
+    public IDictionary<TTSBackend, SortedSet<int>> FemaleVoicePresets { get; init; }
 
     [JsonIgnore] private static readonly JsonSerializerSettings SerializerSettings = new()
     {
@@ -39,10 +39,10 @@ public class VoicePresetConfiguration
         this.cfgLock = true;
 
         VoicePresets = new List<VoicePreset>();
-        CurrentVoicePresets = new Dictionary<TTSBackend, int>();
-        UngenderedVoicePresets = new Dictionary<TTSBackend, int>();
-        MaleVoicePresets = new Dictionary<TTSBackend, int>();
-        FemaleVoicePresets = new Dictionary<TTSBackend, int>();
+        CurrentVoicePreset = new Dictionary<TTSBackend, int>();
+        UngenderedVoicePresets = new Dictionary<TTSBackend, SortedSet<int>>();
+        MaleVoicePresets = new Dictionary<TTSBackend, SortedSet<int>>();
+        FemaleVoicePresets = new Dictionary<TTSBackend, SortedSet<int>>();
     }
 
     public void SaveToFile(string path)

--- a/src/TextToTalk/packages.lock.json
+++ b/src/TextToTalk/packages.lock.json
@@ -57,6 +57,12 @@
           "NAudio.WinMM": "2.1.0"
         }
       },
+      "Standart.Hash.xxHash": {
+        "type": "Direct",
+        "requested": "[4.0.5, )",
+        "resolved": "4.0.5",
+        "contentHash": "2QC9zDPFT/SOnP7iFdK3AwakEcJ7D3zDoU7IwIAOyEhY4WQ2GQBvLqZ29/R1BSujPNtGHMITmVW1d+VjvLg6lg=="
+      },
       "System.Drawing.Common": {
         "type": "Direct",
         "requested": "[6.0.0, )",


### PR DESCRIPTION
Multiple voice presets can be selected for each gender option. They will be randomly assigned to characters, seeded by the hash of the character name, so that the same voices are consistently assigned to the same characters.

Resolves #53.