### PR TITLE
Skip reading voice-acted NPC dialogue

### DIFF
--- a/src/TextToTalk/Middleware/SoundHandler.cs
+++ b/src/TextToTalk/Middleware/SoundHandler.cs
@@ -12,6 +12,8 @@ namespace TextToTalk.Middleware;
 
 public class SoundHandler : IDisposable
 {
+    // Signature strings drawn from Anna Clemens's Sound Filter plugin -
+    // https://git.anna.lgbt/ascclemens/SoundFilter/src/branch/main/SoundFilter/Filter.cs#L12
     private const string LoadSoundFileSig = "E8 ?? ?? ?? ?? 48 85 C0 75 04 B0 F6";
     private const string PlaySpecificSoundSig =
         "48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 33 F6 8B DA 48 8B F9 0F BA E2 0F";

--- a/src/TextToTalk/Middleware/SoundHandler.cs
+++ b/src/TextToTalk/Middleware/SoundHandler.cs
@@ -1,0 +1,142 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+using Dalamud.Game;
+using Dalamud.Hooking;
+using Dalamud.Logging;
+using FFXIVClientStructs.FFXIV.Client.System.Resource.Handle;
+
+namespace TextToTalk.Middleware;
+
+public class SoundHandler : IDisposable
+{
+    private const string LoadSoundFileSig = "E8 ?? ?? ?? ?? 48 85 C0 75 04 B0 F6";
+    private const string PlaySpecificSoundSig =
+        "48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 33 F6 8B DA 48 8B F9 0F BA E2 0F";
+
+    private delegate IntPtr LoadSoundFileDelegate(IntPtr resourceHandlePtr, uint arg2);
+    private delegate IntPtr PlaySpecificSoundDelegate(IntPtr soundPtr, int arg2);
+    
+    private readonly Hook<LoadSoundFileDelegate>? loadSoundFileHook;
+    private readonly Hook<PlaySpecificSoundDelegate>? playSpecificSoundHook;
+
+    private static readonly int ResourceDataOffset = Marshal.SizeOf<ResourceHandle>();
+    private static readonly int SoundDataOffset = Marshal.SizeOf<IntPtr>();
+
+    private const string SoundContainerFileNameSuffix = ".scd";
+    private static readonly Regex IgnoredSoundFileNameRegex = new(
+        @"^(bgcommon|music|sound/(battle|foot|instruments|strm|vfx|voice/Vo_Emote|zingle))/");
+    private static readonly Regex VoiceLineFileNameRegex = new(@"^cut/.*/(vo_|voice)");
+    private readonly HashSet<IntPtr> knownVoiceLinePtrs = new();
+    
+    private readonly TalkAddonHandler talkAddonHandler;
+
+    public SoundHandler(TalkAddonHandler talkAddonHandler, SigScanner sigScanner)
+    {
+        this.talkAddonHandler = talkAddonHandler;
+        
+        if (sigScanner.TryScanText(LoadSoundFileSig, out var loadSoundFilePtr))
+        {
+            this.loadSoundFileHook = Hook<LoadSoundFileDelegate>.FromAddress(loadSoundFilePtr, LoadSoundFileDetour);
+            this.loadSoundFileHook.Enable();
+            PluginLog.Log("Hooked into LoadSoundFile");
+        } else {
+            PluginLog.LogError("Failed to hook into LoadSoundFile");
+        }
+    
+        if (sigScanner.TryScanText(PlaySpecificSoundSig, out var playSpecificSoundPtr))
+        {
+            this.playSpecificSoundHook = Hook<PlaySpecificSoundDelegate>.FromAddress(playSpecificSoundPtr, PlaySpecificSoundDetour);
+            this.playSpecificSoundHook.Enable();
+            PluginLog.Log("Hooked into PlaySpecificSound");
+        } else {
+            PluginLog.LogError("Failed to hook into PlaySpecificSound");
+        }
+    }
+    
+    public void Dispose()
+    {
+        this.loadSoundFileHook?.Dispose();
+        this.playSpecificSoundHook?.Dispose();
+    }
+    
+    private IntPtr LoadSoundFileDetour(IntPtr resourceHandlePtr, uint arg2)
+    {
+        var result = this.loadSoundFileHook!.Original(resourceHandlePtr, arg2);
+
+        try
+        {
+            string fileName;
+            unsafe
+            {
+                fileName = ((ResourceHandle*)resourceHandlePtr)->FileName.ToString();
+            }
+            
+            if (fileName.EndsWith(SoundContainerFileNameSuffix))
+            {
+                var resourceDataPtr = Marshal.ReadIntPtr(resourceHandlePtr + ResourceDataOffset);
+                if (resourceDataPtr != IntPtr.Zero)
+                {
+                    var isVoiceLine = false;
+
+                    if (!IgnoredSoundFileNameRegex.IsMatch(fileName))
+                    {
+                        PluginLog.Log($"Loaded sound: {fileName}");
+
+                        if (VoiceLineFileNameRegex.IsMatch(fileName))
+                        {
+                            isVoiceLine = true;
+                        }
+                    }
+                    
+                    if (isVoiceLine)
+                    {
+                        PluginLog.Log($"Discovered voice line at address {resourceDataPtr:x}");
+                        this.knownVoiceLinePtrs.Add(resourceDataPtr);
+                    }
+                    else
+                    {
+                        // Addresses can be reused, so a non-voice-line sound may be loaded to an address previously
+                        // occupied by a voice line.
+                        if (this.knownVoiceLinePtrs.Remove(resourceDataPtr))
+                        {
+                            PluginLog.Log(
+                                $"Cleared voice line from address {resourceDataPtr:x} (address reused by: {fileName})");
+                        }
+                    }
+                }
+            }
+        }
+        catch (Exception exc)
+        {
+            PluginLog.LogError(exc, "Error in LoadSoundFile detour");
+        }
+
+        return result;
+    }
+
+    private IntPtr PlaySpecificSoundDetour(IntPtr soundPtr, int arg2)
+    {
+        var result = this.playSpecificSoundHook!.Original(soundPtr, arg2);
+
+        try
+        {
+            var soundDataPtr = Marshal.ReadIntPtr(soundPtr + SoundDataOffset);
+            // Assume that a voice line will be played only once after it's loaded. Then the set can be pruned as voice
+            // lines are played.
+            if (this.knownVoiceLinePtrs.Remove(soundDataPtr))
+            {
+                PluginLog.Log($"Caught playback of known voice line at address {soundDataPtr:x}");
+                talkAddonHandler.PollAddon(TalkAddonHandler.PollSource.VoiceLinePlayback);
+            }
+        }
+        catch (Exception exc)
+        {
+            PluginLog.LogError(exc, "Error in PlaySpecificSound detour");
+        }
+
+        return result;
+    }
+}

--- a/src/TextToTalk/PluginConfiguration.cs
+++ b/src/TextToTalk/PluginConfiguration.cs
@@ -118,6 +118,7 @@ namespace TextToTalk
 
         public bool ReadFromQuestTalkAddon { get; set; } = true;
         public bool CancelSpeechOnTextAdvance { get; set; }
+        public bool SkipVoicedQuestText { get; set; } = true;
 
         public bool UseGenderedVoicePresets { get; set; }
 

--- a/src/TextToTalk/UI/ConfigurationWindow.cs
+++ b/src/TextToTalk/UI/ConfigurationWindow.cs
@@ -158,6 +158,13 @@ namespace TextToTalk.UI
                         config.Save();
                     }
 
+                    var skipVoicedQuestText = config.SkipVoicedQuestText;
+                    if (ImGui.Checkbox("Skip reading voice-acted NPC dialogue", ref skipVoicedQuestText))
+                    {
+                        config.SkipVoicedQuestText = skipVoicedQuestText;
+                        config.Save();
+                    }
+
                     ImGui.Unindent();
                 }
 


### PR DESCRIPTION
By hooking into FFXIV's sound management, we can detect when playback starts for voice-acted lines and skip reading out the corresponding text. Voice lines are detected by applying some heuristics to their file names; these heuristics may not be perfect. The file name of a sound is only available when it's loaded, and not later when it's played back, so some care must be taken to correctly keep track of voice line sound resources and their corresponding memory addresses as they're loaded and unloaded by the game.

I consider this experimental, and it'll probably be fine-tuned as I continue to play through the main story with it enabled. I'm submitting this now for early feedback and testing.

Resolves #7.