### PR TITLE
Use R3 instead of System.Reactive; fix save error for existing chat types presets

### DIFF
--- a/src/TextToTalk.Tests/packages.lock.json
+++ b/src/TextToTalk.Tests/packages.lock.json
@@ -63,6 +63,19 @@
         "resolved": "5.0.16",
         "contentHash": "DMUYdRlgNbrSlyWzdQ4GqW934ntNHBGWMTNQlOL4hWz8WnveY6V9ZGo2ntPrSATW7kat8v5VoCXGSzToPiwZWw=="
       },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
+      },
+      "Microsoft.Bcl.TimeProvider": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "f5Kr5JepAbiGo7uDmhgvMqhntwxqXNn6/IpTBSSI4cuHhgnJGrLxFRhMjVpRkLPp6zJXO0/G0l3j9p9zSJxa+w==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+        }
+      },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
         "resolved": "17.5.0",
@@ -245,6 +258,14 @@
         "type": "Transitive",
         "resolved": "5.11.0",
         "contentHash": "eaiXkUjC4NPcquGWzAGMXjuxvLwc6XGKMptSyOGQeT0X70BUZObuybJFZLA0OfTdueLd3US23NBPTBb6iF3V1Q=="
+      },
+      "R3": {
+        "type": "Transitive",
+        "resolved": "1.0.1",
+        "contentHash": "QESbZntZBK5q5d287mK88pcsRaJp6TZpmihT+x6TAfBqbwtwYl2yos9/IbdGH28HjnSxs3GaQI+Vc6UOWq1uag==",
+        "dependencies": {
+          "Microsoft.Bcl.TimeProvider": "8.0.0"
+        }
       },
       "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
         "type": "Transitive",
@@ -678,11 +699,6 @@
           "System.Runtime": "4.3.0",
           "System.Threading": "4.3.0"
         }
-      },
-      "System.Reactive": {
-        "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "erBZjkQHWL9jpasCE/0qKAryzVBJFxGHVBAvgRN1bzM0q2s1S4oYREEEL0Vb+1kA/6BKb5FjUZMp5VXmy+gzkQ=="
       },
       "System.Reflection": {
         "type": "Transitive",
@@ -1173,9 +1189,9 @@
           "DalamudPackager": "[2.1.12, )",
           "Microsoft.CognitiveServices.Speech": "[1.32.1, )",
           "NAudio": "[2.1.0, )",
+          "R3": "[1.0.1, )",
           "Standart.Hash.xxHash": "[4.0.5, )",
           "System.Drawing.Common": "[7.0.0, )",
-          "System.Reactive": "[5.0.0, )",
           "System.Speech": "[7.0.0, )",
           "TextToTalk.Data": "[1.0.0, )",
           "TextToTalk.Lexicons": "[1.0.0, )",

--- a/src/TextToTalk/Backends/System/SystemBackendUIModel.cs
+++ b/src/TextToTalk/Backends/System/SystemBackendUIModel.cs
@@ -2,9 +2,8 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Reactive.Concurrency;
-using System.Reactive.Linq;
 using System.Speech.Synthesis;
+using R3;
 
 namespace TextToTalk.Backends.System;
 
@@ -23,12 +22,7 @@ public class SystemBackendUIModel
         }
     });
 
-    public IReadOnlyDictionary<string, SelectVoiceFailedException> VoiceExceptions { get; private set; }
-
-    public SystemBackendUIModel()
-    {
-        VoiceExceptions = ImmutableDictionary<string, SelectVoiceFailedException>.Empty;
-    }
+    public IReadOnlyDictionary<string, SelectVoiceFailedException> VoiceExceptions { get; private set; } = ImmutableDictionary<string, SelectVoiceFailedException>.Empty;
 
     public List<InstalledVoice> GetInstalledVoices()
     {
@@ -37,10 +31,9 @@ public class SystemBackendUIModel
             : DummySynthesizer.Value.GetInstalledVoices().Where(iv => iv?.Enabled ?? false).ToList();
     }
 
-    public IDisposable SubscribeToVoiceExceptions(IObservable<SelectVoiceFailedException> voiceExceptions)
+    public IDisposable SubscribeToVoiceExceptions(Observable<SelectVoiceFailedException> voiceExceptions)
     {
         return voiceExceptions
-            .SubscribeOn(TaskPoolScheduler.Default)
             .Subscribe(exc =>
             {
                 var imm = ImmutableDictionary.CreateRange(VoiceExceptions.Append(

--- a/src/TextToTalk/Backends/System/SystemSoundQueue.cs
+++ b/src/TextToTalk/Backends/System/SystemSoundQueue.cs
@@ -1,7 +1,7 @@
 ﻿using System;
-using System.Reactive.Subjects;
 using System.Speech.Synthesis;
 using System.Threading;
+using R3;
 using TextToTalk.Lexicons;
 
 namespace TextToTalk.Backends.System
@@ -12,7 +12,7 @@ namespace TextToTalk.Backends.System
         private readonly LexiconManager lexiconManager;
         private readonly AutoResetEvent speechCompleted;
 
-        public IObservable<SelectVoiceFailedException> SelectVoiceFailed => selectVoiceFailed;
+        public Observable<SelectVoiceFailedException> SelectVoiceFailed => selectVoiceFailed;
         private readonly Subject<SelectVoiceFailedException> selectVoiceFailed;
 
         public SystemSoundQueue(LexiconManager lexiconManager)

--- a/src/TextToTalk/Backends/VoiceBackendManager.cs
+++ b/src/TextToTalk/Backends/VoiceBackendManager.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Net.Http;
 using System.Numerics;
-using System.Reactive.Subjects;
 using System.Threading.Tasks;
 using Dalamud.Interface;
+using R3;
 using TextToTalk.Backends.Azure;
 using TextToTalk.Backends.ElevenLabs;
 using TextToTalk.Backends.Polly;
@@ -60,7 +60,7 @@ namespace TextToTalk.Backends
             return Backend?.GetCurrentlySpokenTextSource() ?? TextSource.None;
         }
 
-        public IObservable<int> OnFailedToBindWSPort()
+        public Observable<int> OnFailedToBindWSPort()
         {
             return this.onFailedToBindWsPort;
         }
@@ -76,7 +76,8 @@ namespace TextToTalk.Backends
                 {
                     var wsBackend = newBackend as WebsocketBackend;
                     this.handleFailedToBindWsPort =
-                        wsBackend?.OnFailedToBindPort().Subscribe(this.onFailedToBindWsPort);
+                        wsBackend?.OnFailedToBindPort().SubscribeOnThreadPool()
+                            .Subscribe(this.onFailedToBindWsPort.AsObserver());
                 }
 
                 Backend = newBackend;

--- a/src/TextToTalk/Backends/Websocket/WebsocketBackend.cs
+++ b/src/TextToTalk/Backends/Websocket/WebsocketBackend.cs
@@ -2,8 +2,8 @@
 using System;
 using System.Net.Sockets;
 using System.Numerics;
-using System.Reactive.Subjects;
 using System.Text;
+using R3;
 using TextToTalk.UI;
 
 namespace TextToTalk.Backends.Websocket
@@ -35,7 +35,7 @@ namespace TextToTalk.Backends.Websocket
             this.wsServer.Start();
         }
 
-        public IObservable<int> OnFailedToBindPort()
+        public Observable<int> OnFailedToBindPort()
         {
             return this.failedToBindPort;
         }

--- a/src/TextToTalk/DisposeHandler.cs
+++ b/src/TextToTalk/DisposeHandler.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace TextToTalk;
+
+public class DisposeHandler : IDisposable
+{
+    private readonly Action dispose;
+
+    public DisposeHandler(Action dispose)
+    {
+        this.dispose = dispose;
+    }
+
+    public void Dispose()
+    {
+        this.dispose();
+    }
+}

--- a/src/TextToTalk/EnabledChatTypesPreset.cs
+++ b/src/TextToTalk/EnabledChatTypesPreset.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using TextToTalk.UI.Core;
 
 namespace TextToTalk;
@@ -19,15 +20,27 @@ public class EnabledChatTypesPreset : ISaveable
 
     public VirtualKey.Enum MajorKey { get; set; }
 
-    private readonly PluginConfiguration config;
+    private PluginConfiguration? config;
 
     public EnabledChatTypesPreset(PluginConfiguration config)
     {
         this.config = config;
     }
 
+    public void Initialize(PluginConfiguration pluginConfiguration)
+    {
+        // When loaded from an existing config file, the constructor is not properly
+        // invoked, so we need to support late-initialization here.
+        this.config = pluginConfiguration;
+    }
+
     public void Save()
     {
-        this.config.Save();
+        if (this.config is null)
+        {
+            throw new InvalidOperationException("No config is attached to this chat types preset.");
+        }
+
+        this.config?.Save();
     }
 }

--- a/src/TextToTalk/PluginConfiguration.cs
+++ b/src/TextToTalk/PluginConfiguration.cs
@@ -200,6 +200,11 @@ namespace TextToTalk
 
             EnabledChatTypesPresets ??= new List<EnabledChatTypesPreset>();
 
+            foreach (var preset in EnabledChatTypesPresets)
+            {
+                preset.Initialize(this);
+            }
+
             AzureLexiconFiles ??= new List<string>();
             PollyLexiconFiles ??= new List<string>();
             Lexicons ??= new List<string>();

--- a/src/TextToTalk/TextToTalk.Observable.cs
+++ b/src/TextToTalk/TextToTalk.Observable.cs
@@ -1,65 +1,64 @@
-﻿using System;
-using System.Linq;
-using System.Reactive.Linq;
+﻿using System.Linq;
+using R3;
 using TextToTalk.Events;
 
 namespace TextToTalk;
 
 public partial class TextToTalk
 {
-    private IObservable<ChatTextEmitEvent> OnChatTextEmit()
+    private Observable<ChatTextEmitEvent> OnChatTextEmit()
     {
         return Observable.FromEvent<ChatTextEmitEvent>(
                 h => this.chatMessageHandler.OnTextEmit += h,
                 h => this.chatMessageHandler.OnTextEmit -= h)
-            .Where(ev =>
+            .Where(this, static (ev, p) =>
             {
                 // Check all of the other filters to see if this should be dropped
-                var chatTypes = this.config.GetCurrentEnabledChatTypesPreset();
+                var chatTypes = p.config.GetCurrentEnabledChatTypesPreset();
                 var typeEnabled = chatTypes.EnabledChatTypes is not null &&
                                   chatTypes.EnabledChatTypes.Contains((int)ev.ChatType);
                 return chatTypes.EnableAllChatTypes || typeEnabled;
             })
-            .Where(ev => !IsTextBad(ev.Text.TextValue))
-            .Where(ev => IsTextGood(ev.Text.TextValue));
+            .Where(this, static (ev, p) => !p.IsTextBad(ev.Text.TextValue))
+            .Where(this, static (ev, p) => p.IsTextGood(ev.Text.TextValue));
     }
 
-    private IObservable<TextEmitEvent> OnTalkAddonTextEmit()
+    private Observable<TextEmitEvent> OnTalkAddonTextEmit()
     {
         return Observable.FromEvent<TextEmitEvent>(
             h => this.addonTalkHandler.OnTextEmit += h,
             h => this.addonTalkHandler.OnTextEmit -= h);
     }
 
-    private IObservable<TextEmitEvent> OnBattleTalkAddonTextEmit()
+    private Observable<TextEmitEvent> OnBattleTalkAddonTextEmit()
     {
         return Observable.FromEvent<TextEmitEvent>(
             h => this.addonBattleTalkHandler.OnTextEmit += h,
             h => this.addonBattleTalkHandler.OnTextEmit -= h);
     }
 
-    private IObservable<AddonTalkAdvanceEvent> OnTalkAddonAdvance()
+    private Observable<AddonTalkAdvanceEvent> OnTalkAddonAdvance()
     {
         return Observable.FromEvent<AddonTalkAdvanceEvent>(
             h => this.addonTalkHandler.OnAdvance += h,
             h => this.addonTalkHandler.OnAdvance -= h);
     }
 
-    private IObservable<AddonTalkCloseEvent> OnTalkAddonClose()
+    private Observable<AddonTalkCloseEvent> OnTalkAddonClose()
     {
         return Observable.FromEvent<AddonTalkCloseEvent>(
             h => this.addonTalkHandler.OnClose += h,
             h => this.addonTalkHandler.OnClose -= h);
     }
 
-    private IObservable<SourcedTextEvent> OnTextSourceCancel()
+    private Observable<SourcedTextEvent> OnTextSourceCancel()
     {
-        return OnTalkAddonAdvance().Merge<SourcedTextEvent>(OnTalkAddonClose());
+        return OnTalkAddonAdvance().Cast<AddonTalkAdvanceEvent, SourcedTextEvent>().Merge(OnTalkAddonClose().Cast<AddonTalkCloseEvent, SourcedTextEvent>());
     }
 
-    private IObservable<TextEmitEvent> OnTextEmit()
+    private Observable<TextEmitEvent> OnTextEmit()
     {
-        return OnTalkAddonTextEmit().Merge(OnChatTextEmit()).Merge(OnBattleTalkAddonTextEmit());
+        return OnTalkAddonTextEmit().Merge(OnChatTextEmit().Cast<ChatTextEmitEvent, TextEmitEvent>()).Merge(OnBattleTalkAddonTextEmit());
     }
 
     private bool IsTextGood(string text)

--- a/src/TextToTalk/TextToTalk.csproj
+++ b/src/TextToTalk/TextToTalk.csproj
@@ -39,9 +39,9 @@
         <PackageReference Include="DalamudPackager" Version="2.1.12" />
         <PackageReference Include="Microsoft.CognitiveServices.Speech" Version="1.32.1" />
         <PackageReference Include="NAudio" Version="2.1.0"/>
+        <PackageReference Include="R3" Version="1.0.1" />
         <PackageReference Include="Standart.Hash.xxHash" Version="4.0.5"/>
         <PackageReference Include="System.Drawing.Common" Version="7.0.0"/>
-        <PackageReference Include="System.Reactive" Version="5.0.0"/>
         <PackageReference Include="System.Speech" Version="7.0.0"/>
     </ItemGroup>
 

--- a/src/TextToTalk/UI/ConfigurationWindow.cs
+++ b/src/TextToTalk/UI/ConfigurationWindow.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
-using System.Reactive.Subjects;
 using System.Text;
 using Dalamud.Game.Text;
 using Dalamud.Interface;
@@ -10,6 +9,7 @@ using Dalamud.Interface.Windowing;
 using Dalamud.Plugin.Services;
 using ImGuiNET;
 using Lumina.Excel.GeneratedSheets;
+using R3;
 using TextToTalk.Backends;
 using TextToTalk.Data.Model;
 using TextToTalk.GameEnums;
@@ -54,7 +54,7 @@ namespace TextToTalk.UI
             SizeCondition = ImGuiCond.FirstUseEver;
         }
 
-        public IObservable<bool> OnPresetOpenRequested()
+        public Observable<bool> OnPresetOpenRequested()
         {
             return this.onPresetOpenRequested;
         }

--- a/src/TextToTalk/UI/VoiceUnlockerWindow.cs
+++ b/src/TextToTalk/UI/VoiceUnlockerWindow.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Numerics;
-using System.Reactive.Subjects;
 using Dalamud.Interface.Windowing;
 using ImGuiNET;
+using R3;
 
 namespace TextToTalk.UI
 {
@@ -26,7 +26,7 @@ namespace TextToTalk.UI
             SizeCondition = ImGuiCond.FirstUseEver;
         }
 
-        public IObservable<string> OnResult()
+        public Observable<string> OnResult()
         {
             return this.onResult;
         }

--- a/src/TextToTalk/packages.lock.json
+++ b/src/TextToTalk/packages.lock.json
@@ -43,6 +43,15 @@
           "NAudio.WinMM": "2.1.0"
         }
       },
+      "R3": {
+        "type": "Direct",
+        "requested": "[1.0.1, )",
+        "resolved": "1.0.1",
+        "contentHash": "QESbZntZBK5q5d287mK88pcsRaJp6TZpmihT+x6TAfBqbwtwYl2yos9/IbdGH28HjnSxs3GaQI+Vc6UOWq1uag==",
+        "dependencies": {
+          "Microsoft.Bcl.TimeProvider": "8.0.0"
+        }
+      },
       "Standart.Hash.xxHash": {
         "type": "Direct",
         "requested": "[4.0.5, )",
@@ -57,12 +66,6 @@
         "dependencies": {
           "Microsoft.Win32.SystemEvents": "7.0.0"
         }
-      },
-      "System.Reactive": {
-        "type": "Direct",
-        "requested": "[5.0.0, )",
-        "resolved": "5.0.0",
-        "contentHash": "erBZjkQHWL9jpasCE/0qKAryzVBJFxGHVBAvgRN1bzM0q2s1S4oYREEEL0Vb+1kA/6BKb5FjUZMp5VXmy+gzkQ=="
       },
       "System.Speech": {
         "type": "Direct",
@@ -79,6 +82,19 @@
         "type": "Transitive",
         "resolved": "5.0.16",
         "contentHash": "DMUYdRlgNbrSlyWzdQ4GqW934ntNHBGWMTNQlOL4hWz8WnveY6V9ZGo2ntPrSATW7kat8v5VoCXGSzToPiwZWw=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
+      },
+      "Microsoft.Bcl.TimeProvider": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "f5Kr5JepAbiGo7uDmhgvMqhntwxqXNn6/IpTBSSI4cuHhgnJGrLxFRhMjVpRkLPp6zJXO0/G0l3j9p9zSJxa+w==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+        }
       },
       "Microsoft.NETCore.Platforms": {
         "type": "Transitive",


### PR DESCRIPTION
* Switch to R3 because the API is nicer than System.Reactive
* Fix an error when making changes to existing chat types presets