### PR TITLE
Fix openai api key not being saved

### DIFF
--- a/src/TextToTalk/Backends/OpenAI/OpenAiBackendUI.cs
+++ b/src/TextToTalk/Backends/OpenAI/OpenAiBackendUI.cs
@@ -9,24 +9,26 @@ public class OpenAiBackendUI
 {
     private readonly OpenAiClient client;
     private readonly PluginConfiguration config;
+    
+    private string apiKey;
 
     public OpenAiBackendUI(PluginConfiguration config, OpenAiClient client)
     {
         this.config = config;
         this.client = client;
-        client.ApiKey = OpenAiCredentialManager.GetApiKey();
+        apiKey = OpenAiCredentialManager.GetApiKey();
+        this.client.ApiKey = apiKey;
     }
 
     public void DrawLoginOptions()
     {
-        var apiKey = client.ApiKey;
         ImGui.InputTextWithHint($"##{MemoizedId.Create()}", "API key", ref apiKey, 100,
             ImGuiInputTextFlags.Password);
 
-        if (ImGui.Button($"Login##{MemoizedId.Create()}"))
+        if (ImGui.Button($"Save##{MemoizedId.Create()}"))
         {
             OpenAiCredentialManager.SaveCredentials(apiKey);
-            client.ApiKey = apiKey;
+            this.client.ApiKey = apiKey;
         }
     }
 


### PR DESCRIPTION
https://github.com/karashiiro/TextToTalk/issues/210

Previously the openai api key would never be saved since it's value was being retrieved from the client.ApiKey property each draw

oops