### PR TITLE
Exclude Unsupported Runtimes from build output

### DIFF
--- a/src/TextToTalk/TextToTalk.csproj
+++ b/src/TextToTalk/TextToTalk.csproj
@@ -61,4 +61,16 @@
         <Copy SourceFiles="@(VoiceUnlocker)" DestinationFolder="$(TargetDir)\VoiceUnlocker" SkipUnchangedFiles="true" />
     </Target>
 
+    <Target Name="_ExcludeUnsupportedRuntimes" BeforeTargets="_CopyFilesMarkedCopyLocal">
+        <ItemGroup>
+            <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" Condition="$([System.String]::new('%(ReferenceCopyLocalPaths.RuntimeIdentifier)').StartsWith('android'))" />
+            <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" Condition="$([System.String]::new('%(ReferenceCopyLocalPaths.RuntimeIdentifier)').StartsWith('ios'))" />
+            <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" Condition="$([System.String]::new('%(ReferenceCopyLocalPaths.RuntimeIdentifier)').StartsWith('osx'))" />
+            <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" Condition="$([System.String]::new('%(ReferenceCopyLocalPaths.RuntimeIdentifier)').StartsWith('maccatalyst'))" />
+            <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" Condition="$([System.String]::new('%(ReferenceCopyLocalPaths.RuntimeIdentifier)').EndsWith('-arm'))" />
+            <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" Condition="$([System.String]::new('%(ReferenceCopyLocalPaths.RuntimeIdentifier)').EndsWith('-arm64'))" />
+            <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" Condition="$([System.String]::new('%(ReferenceCopyLocalPaths.RuntimeIdentifier)').EndsWith('-x86'))" />
+        </ItemGroup>
+    </Target>
+
 </Project>


### PR DESCRIPTION
This will exclude all files from the `runtimes` folder except for the ones from `linux-x64`, `win`, and `win-x64`.

I'm pretty sure FFXIV is x64-only and doesn't run on Mac, Android or IOS, so there is no need to add other runtimes.
(Please correct me if I'm wrong)

This would reduce the size of the plugin from 209 MB to 22.6 MB (~89% smaller).