### PR TITLE
Streaming SoundQueue refactor.  Addition of Latency Metrics. Addition of Piper backend

### DIFF
--- a/src/TextToTalk.Lexicons/LexiconManager.cs
+++ b/src/TextToTalk.Lexicons/LexiconManager.cs
@@ -97,6 +97,7 @@ public class LexiconManager
         bool includeSpeakAttributes = true)
 
     {
+        text = System.Security.SecurityElement.Escape(text);
         foreach (var (_, lexicon) in this.lexicons)
         {
             foreach (var lexeme in lexicon.Lexemes.Where(lexeme => text.Contains(lexeme.Grapheme)))

--- a/src/TextToTalk.Tests/packages.lock.json
+++ b/src/TextToTalk.Tests/packages.lock.json
@@ -372,10 +372,29 @@
         "resolved": "5.0.0-pre.13",
         "contentHash": "65qbZS49AfrTM6jtZ2RDTWAzLe13ywCXIiSP5QrAJLmZT6sQqHGd1LfFXLhx8Ccp77qy7qh/LHsxpUOlkgZTCg=="
       },
+      "PiperSharp": {
+        "type": "Transitive",
+        "resolved": "1.0.6",
+        "contentHash": "g68TbampKc0ATx80nur6LHHrhIpXvmioIVuwAuWKcjTXTB2tf+Klk4JPwzWZRo+DRSR4kS370eh+davEQVR0cw==",
+        "dependencies": {
+          "NAudio": "2.2.1",
+          "NAudio.Core": "2.2.1",
+          "Newtonsoft.Json": "13.0.1",
+          "SharpCompress": "0.36.0"
+        }
+      },
       "R3": {
         "type": "Transitive",
         "resolved": "1.2.9",
         "contentHash": "dKMFt90XW+n7JK2P40dx9uuLg57Pcj4cA/9n1NwdKWFcMAM6j49OU8h9EborpVe4KXI+2MV/EjKc1LG7fhQJUA=="
+      },
+      "SharpCompress": {
+        "type": "Transitive",
+        "resolved": "0.36.0",
+        "contentHash": "48am//T6Ou+GmyPmBaxaFN1ym0VNidRcBeANr9+OYTzpKRz8QMGzAkHVkCV30lFQ/gnWqGr50AuebahpG1C6xA==",
+        "dependencies": {
+          "ZstdSharp.Port": "0.7.4"
+        }
       },
       "Standart.Hash.xxHash": {
         "type": "Transitive",
@@ -477,6 +496,11 @@
         "resolved": "15.3.0",
         "contentHash": "F93japYa9YrJ59AZGhgdaUGHN7ITJ55FBBg/D/8C0BDgahv/rQD6MOSwHxOJJpon1kYyslVbeBrQ2wcJhox01w=="
       },
+      "ZstdSharp.Port": {
+        "type": "Transitive",
+        "resolved": "0.7.4",
+        "contentHash": "ziptnotpUJr51afwXJQ5Wc03dvDiZAdmxS08s1g7SHn/VzbyZUXdH6yORk/zaNjzUOEE6pVZ0Nqztab0rYROgQ=="
+      },
       "texttotalk": {
         "type": "Project",
         "dependencies": {
@@ -488,6 +512,7 @@
           "Microsoft.CognitiveServices.Speech": "[1.41.1, )",
           "NAudio": "[2.2.1, )",
           "OpenAI": "[2.8.0, )",
+          "PiperSharp": "[1.0.6, )",
           "R3": "[1.2.9, )",
           "Standart.Hash.xxHash": "[4.0.5, )",
           "System.Drawing.Common": "[9.0.0, )",

--- a/src/TextToTalk.Tests/packages.lock.json
+++ b/src/TextToTalk.Tests/packages.lock.json
@@ -87,119 +87,114 @@
         "resolved": "14.0.1",
         "contentHash": "y0WWyUE6dhpGdolK3iKgwys05/nZaVf4ZPtIjpLhJBZvHxkkiE23zYRo7K7uqAgoK/QvK5cqF6l3VG5AbgC6KA=="
       },
-      "Fare": {
-        "type": "Transitive",
-        "resolved": "2.2.1",
-        "contentHash": "21XZo/yuXK1k0EUhdLnjgRD4n0HQYmPFchV6uaORcRc65rasZ1vdm2dmJXPBKZiIBztRRYRmmg/B76W721VWkA=="
-      },
       "Google.Api.CommonProtos": {
         "type": "Transitive",
-        "resolved": "2.16.0",
-        "contentHash": "37MuZrE9AAqHAdYgFLoTHydAiXDRriQZGVKEg6fr6ASnrY5GtauYXnQrGk5x2K3NmYzEXe+wkpaPVmxjb3NKjg==",
+        "resolved": "2.17.0",
+        "contentHash": "elfQPknFr495hm7vdy6ZlgyQh6yzZq9TU7sS35L/Fj/fqjM/mUGau9gVJLhvQEtUlPjtR80hpn/m9HvBMyCXIw==",
         "dependencies": {
-          "Google.Protobuf": "[3.28.2, 4.0.0)"
+          "Google.Protobuf": "[3.31.1, 4.0.0]"
         }
       },
       "Google.Api.Gax": {
         "type": "Transitive",
-        "resolved": "4.9.0",
-        "contentHash": "fjHHYcQ99u0ztqwT537rvVtJMdDy6G2VHBZ+F1cBjDGYNVZfrpk40DMQ/OpUGToT9ZGHVirhh3eJ73bw2ANVPQ==",
+        "resolved": "4.12.1",
+        "contentHash": "G62dRNOv5DolfRviT6CCrL2a5nZ/CWWdRzhADkGnpCkYSOc3QnH5xxRvZiOKuHU8weJ/pAqAqrj7+T9IWdlu2Q==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
-          "Newtonsoft.Json": "13.0.3"
+          "Newtonsoft.Json": "13.0.4"
         }
       },
       "Google.Api.Gax.Grpc": {
         "type": "Transitive",
-        "resolved": "4.9.0",
-        "contentHash": "ToCx/0cs+wJ9j7vzKRcPAKneJVZrz/s9JhW9QsFx1dar9WzTxawQZ8xTjyieSy8tY0UiYCL1qYkn/iRrklYnSA==",
+        "resolved": "4.12.1",
+        "contentHash": "W3LjuitOWxWyvbwqeHvpgp0LdshEiTnw/pneDAfAhQ02VgU2gVEzSXfGNPsvL8hDPBXjngR/fWNme8Kungwwkw==",
         "dependencies": {
-          "Google.Api.CommonProtos": "2.16.0",
-          "Google.Api.Gax": "4.9.0",
-          "Google.Apis.Auth": "1.68.0",
-          "Grpc.Auth": "2.66.0",
-          "Grpc.Core.Api": "2.66.0",
-          "Grpc.Net.Client": "2.66.0",
+          "Google.Api.CommonProtos": "2.17.0",
+          "Google.Api.Gax": "4.12.1",
+          "Google.Apis.Auth": "1.72.0",
+          "Grpc.Auth": "[2.71.0, 3.0.0)",
+          "Grpc.Core.Api": "[2.71.0, 3.0.0)",
+          "Grpc.Net.Client": "[2.71.0, 3.0.0)",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0"
         }
       },
       "Google.Apis": {
         "type": "Transitive",
-        "resolved": "1.68.0",
-        "contentHash": "s2MymhdpH+ybZNBeZ2J5uFgFHApBp+QXf9FjZSdM1lk/vx5VqIknJwnaWiuAzXxPrLEkesX0Q+UsiWn39yZ9zw==",
+        "resolved": "1.72.0",
+        "contentHash": "QbSJ08W7QuqsfzDPOZDHl1aFzCYwMcfBoHqQRh7koglwDN5WacShCKYMpU/zR1Pf3h3sH6JTGEeM/txAxaJuEg==",
         "dependencies": {
-          "Google.Apis.Core": "1.68.0"
+          "Google.Apis.Core": "1.72.0"
         }
       },
       "Google.Apis.Auth": {
         "type": "Transitive",
-        "resolved": "1.68.0",
-        "contentHash": "hFx8Qz5bZ4w0hpnn4tSmZaaFpjAMsgVElZ+ZgVLUZ2r9i+AKcoVgwiNfv1pruNS5cCvpXqhKECbruBCfRezPHA==",
+        "resolved": "1.72.0",
+        "contentHash": "RBoFwFKBHKUjuyJf2weEnqICQLaY0TdIrdFv2yC8bsiR2VFYxizOn3C/qN1FWCCb0Uh9GhW+zwAV1yUxPjiocw==",
         "dependencies": {
-          "Google.Apis": "1.68.0",
-          "Google.Apis.Core": "1.68.0",
+          "Google.Apis": "1.72.0",
+          "Google.Apis.Core": "1.72.0",
           "System.Management": "7.0.2"
         }
       },
       "Google.Apis.Core": {
         "type": "Transitive",
-        "resolved": "1.68.0",
-        "contentHash": "pAqwa6pfu53UXCR2b7A/PAPXeuVg6L1OFw38WckN27NU2+mf+KTjoEg2YGv/f0UyKxzz7DxF1urOTKg/6dTP9g==",
+        "resolved": "1.72.0",
+        "contentHash": "ZmYX1PU0vTKFT42c7gp4zaYcb/0TFAXrt9qw8yEz0wjvaug85+/WddlPTfT525Qei8iIUsF6t4bHYrsb2O7crg==",
         "dependencies": {
-          "Newtonsoft.Json": "13.0.3"
+          "Newtonsoft.Json": "13.0.4"
         }
       },
       "Google.Cloud.TextToSpeech.V1": {
         "type": "Transitive",
-        "resolved": "3.9.0",
-        "contentHash": "JpejhPzzEQ6rdaf0nsjjJwj1CJb8Zs0x+TH27+A17KF2g0NqrgtAbpkUZTiGlQHhOzJSF1lB3amrQhbGjozJ3A==",
+        "resolved": "3.17.0",
+        "contentHash": "27vM1NEBmCqAwqagwS0aEHfRBrFy7z6Ef+BblwKMaxtUUY0amdUdeXLY/PU8RSIHtJoan1K6ZKIS6YYqzgp77g==",
         "dependencies": {
-          "Google.Api.Gax.Grpc": "[4.9.0, 5.0.0)",
-          "Google.LongRunning": "[3.3.0, 4.0.0)"
+          "Google.Api.Gax.Grpc": "[4.12.1, 5.0.0)",
+          "Google.LongRunning": "[3.5.0, 4.0.0)"
         }
       },
       "Google.LongRunning": {
         "type": "Transitive",
-        "resolved": "3.3.0",
-        "contentHash": "F2SZ83Jo466Wj/s1Z7QhIAmWBXxJZQyXZpcx0P8BR7d6s0FAj67vQjeUPESSJcvsy8AqYiYBhkUr2YpZhTQeHg==",
+        "resolved": "3.5.0",
+        "contentHash": "W8xO6FA+rG8WjKOsyIjTKjeKLcyCrjBBYeEdZ4QBkKQcxmRczbrfKhKQmdorb2V35CqXeeTbue5Na6Zkgyv8ow==",
         "dependencies": {
-          "Google.Api.Gax.Grpc": "[4.8.0, 5.0.0)"
+          "Google.Api.Gax.Grpc": "[4.12.1, 5.0.0)"
         }
       },
       "Google.Protobuf": {
         "type": "Transitive",
-        "resolved": "3.28.2",
-        "contentHash": "Z86ZKAB+v1B/m0LTM+EVamvZlYw/g3VND3/Gs4M/+aDIxa2JE9YPKjDxTpf0gv2sh26hrve3eI03brxBmzn92g=="
+        "resolved": "3.31.1",
+        "contentHash": "gSnJbUmGiOTdWddPhqzrEscHq9Ls6sqRDPB9WptckyjTUyx70JOOAaDLkFff8gManZNN3hllQ4aQInnQyq/Z/A=="
       },
       "Grpc.Auth": {
         "type": "Transitive",
-        "resolved": "2.66.0",
-        "contentHash": "FRQlhMAcHf0GjAXIfhN6RydfZncLLXNNTOtpLL1bt57kp59vu40faW+dr6Vwl7ef/IUFfF38aiB5jvhAA/9Aow==",
+        "resolved": "2.71.0",
+        "contentHash": "t2aGh/pMgqmc3GimtYfC7VcgVY/VSbk6SLH+61wewsgK45tzxxD9nYYItT5bpLn7fbebirmHXfgJcVKIArd0cg==",
         "dependencies": {
-          "Google.Apis.Auth": "1.68.0",
-          "Grpc.Core.Api": "2.66.0"
+          "Google.Apis.Auth": "1.69.0",
+          "Grpc.Core.Api": "2.71.0"
         }
       },
       "Grpc.Core.Api": {
         "type": "Transitive",
-        "resolved": "2.66.0",
-        "contentHash": "HsjsQVAHe4hqP4t4rpUnmq+MZvPdyrlPsWF4T5fbMvyP3o/lMV+KVJfDlaNH8+v0aGQTVT3EsDFufbhaWb52cw=="
+        "resolved": "2.71.0",
+        "contentHash": "QquqUC37yxsDzd1QaDRsH2+uuznWPTS8CVE2Yzwl3CvU4geTNkolQXoVN812M2IwT6zpv3jsZRc9ExJFNFslTg=="
       },
       "Grpc.Net.Client": {
         "type": "Transitive",
-        "resolved": "2.66.0",
-        "contentHash": "GwkSsssXFgN9+M2U+UQWdErf61sn1iqgP+2NRBlDXATcP9vlxda0wySxd/eIL8U522+SnyFNUXlvQ5tAzGk9cA==",
+        "resolved": "2.71.0",
+        "contentHash": "U1vr20r5ngoT9nlb7wejF28EKN+taMhJsV9XtK9MkiepTZwnKxxiarriiMfCHuDAfPUm9XUjFMn/RIuJ4YY61w==",
         "dependencies": {
-          "Grpc.Net.Common": "2.66.0",
+          "Grpc.Net.Common": "2.71.0",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.0"
         }
       },
       "Grpc.Net.Common": {
         "type": "Transitive",
-        "resolved": "2.66.0",
-        "contentHash": "YJpQpIvpo0HKlsG6SHwaieyji08qfv0DdEDIewCAA0egQY08637sHOj1netLGUhzBEsCqlGC3e92TZ2uqhxnvw==",
+        "resolved": "2.71.0",
+        "contentHash": "v0c8R97TwRYwNXlC8GyRXwYTCNufpDfUtj9la+wUrZFzVWkFJuNAltU+c0yI3zu0jl54k7en6u2WKgZgd57r2Q==",
         "dependencies": {
-          "Grpc.Core.Api": "2.66.0"
+          "Grpc.Core.Api": "2.71.0"
         }
       },
       "KokoroSharp": {
@@ -245,13 +240,16 @@
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "xlzi2IYREJH3/m6+lUrQlujzX8wDitm4QGnUu6kUXTQAWPuZY8i+ticFJbzfqaetLA6KR/rO6Ew/HuYD+bxifg=="
+        "resolved": "8.0.2",
+        "contentHash": "3iE7UF7MQkCv1cxzCahz+Y/guQbTqieyxyaWKhrRO91itI9cOKO76OHeQDahqG4MmW5umr3CcCvGmK92lWNlbg=="
       },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "/HggWBbTwy8TgebGSX5DBZ24ndhzi93sHUBDvP1IxbZD7FDokYzdAr6+vbWGjw2XAfR2EJ1sfKUotpjHnFWPxA=="
+        "resolved": "8.0.3",
+        "contentHash": "dL0QGToTxggRLMYY4ZYX5AMwBb+byQBd/5dMiZE07Nv73o6I5Are3C7eQTh7K2+A4ct0PVISSr7TZANbiNb2yQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2"
+        }
       },
       "Microsoft.ML.OnnxRuntime": {
         "type": "Transitive",
@@ -339,13 +337,21 @@
       },
       "Newtonsoft.Json": {
         "type": "Transitive",
-        "resolved": "13.0.3",
-        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+        "resolved": "13.0.4",
+        "contentHash": "pdgNNMai3zv51W5aq268sujXUyx7SNdE2bj1wZcWjAQrKMFZV260lbqYop1d2GM67JI1huLRwxo9ZqnfF/lC6A=="
       },
       "NumSharp": {
         "type": "Transitive",
         "resolved": "0.30.0",
         "contentHash": "1f8m2B/m/ZSsICaqLszspCyA9/sTHK7wBKEH5KsxGg/r3QCYTc2HnfYOGMeCytvo8/j0v/umn5umLOLhdExlFA=="
+      },
+      "OpenAI": {
+        "type": "Transitive",
+        "resolved": "2.8.0",
+        "contentHash": "KcYpZ9IhuxFD2hGAJlL5vABtkr00CjeJU0SY8CjZQyzvzkzLop8jhdX3iDvteVJg6e3y4TEiY+Kti4gDJAagnA==",
+        "dependencies": {
+          "System.ClientModel": "1.8.1"
+        }
       },
       "OpenTK.Audio.OpenAL": {
         "type": "Transitive",
@@ -376,6 +382,15 @@
         "resolved": "4.0.5",
         "contentHash": "2QC9zDPFT/SOnP7iFdK3AwakEcJ7D3zDoU7IwIAOyEhY4WQ2GQBvLqZ29/R1BSujPNtGHMITmVW1d+VjvLg6lg=="
       },
+      "System.ClientModel": {
+        "type": "Transitive",
+        "resolved": "1.8.1",
+        "contentHash": "4oUQgw/vaO4FBOk3YsH40hbrjxRED1l95rRLvTMtHXfQxapXya9IfPpm/KgwValFFtYTfYGFOs/qzGmGyexicQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
+          "System.Memory.Data": "8.0.1"
+        }
+      },
       "System.CodeDom": {
         "type": "Transitive",
         "resolved": "7.0.0",
@@ -401,6 +416,11 @@
         "dependencies": {
           "System.CodeDom": "7.0.0"
         }
+      },
+      "System.Memory.Data": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "BVYuec3jV23EMRDeR7Dr1/qhx7369dZzJ9IWy2xylvb4YfXsrUxspWc4UWYid/tj4zZK58uGZqn2WQiaDMhmAg=="
       },
       "System.Numerics.Tensors": {
         "type": "Transitive",
@@ -463,11 +483,11 @@
           "AWSSDK.Polly": "[3.7.401.37, )",
           "AdysTech.CredentialManager": "[2.6.0, )",
           "DalamudPackager": "[14.0.1, )",
-          "Fare": "[2.2.1, )",
-          "Google.Cloud.TextToSpeech.V1": "[3.9.0, )",
+          "Google.Cloud.TextToSpeech.V1": "[3.17.0, )",
           "KokoroSharp.CPU": "[0.6.1, )",
           "Microsoft.CognitiveServices.Speech": "[1.41.1, )",
           "NAudio": "[2.2.1, )",
+          "OpenAI": "[2.8.0, )",
           "R3": "[1.2.9, )",
           "Standart.Hash.xxHash": "[4.0.5, )",
           "System.Drawing.Common": "[9.0.0, )",

--- a/src/TextToTalk.Tests/packages.lock.json
+++ b/src/TextToTalk.Tests/packages.lock.json
@@ -259,10 +259,36 @@
           "Microsoft.ML.OnnxRuntime.Managed": "1.22.0"
         }
       },
+      "Microsoft.ML.OnnxRuntime.Gpu": {
+        "type": "Transitive",
+        "resolved": "1.23.2",
+        "contentHash": "4GNQUc6FHiWHvp95Yhu95SUDa6HVm+RSQxm7QCH3PIlderDhTPdU98fHHKXmLy4xIQikkEraMcGe+KXEQU5tew==",
+        "dependencies": {
+          "Microsoft.ML.OnnxRuntime.Gpu.Linux": "1.23.2",
+          "Microsoft.ML.OnnxRuntime.Gpu.Windows": "1.23.2",
+          "Microsoft.ML.OnnxRuntime.Managed": "1.23.2"
+        }
+      },
+      "Microsoft.ML.OnnxRuntime.Gpu.Linux": {
+        "type": "Transitive",
+        "resolved": "1.23.2",
+        "contentHash": "bcv2zpP8GNnfdUCkOjE9lzIoslAOCuY0T9QHpI5+Qm6qUcehRPtGC8wF4nvySwyfTe0g3rVINP3SSj1zinkE7Q==",
+        "dependencies": {
+          "Microsoft.ML.OnnxRuntime.Managed": "1.23.2"
+        }
+      },
+      "Microsoft.ML.OnnxRuntime.Gpu.Windows": {
+        "type": "Transitive",
+        "resolved": "1.23.2",
+        "contentHash": "qOU3DVcxq4XalFV3wlrNrdatYWufIqvg8FZqVC3LS2rFPoTfl++xpMC2nnaxB2Wc5jrpDb2izrcDsQatCyjVnA==",
+        "dependencies": {
+          "Microsoft.ML.OnnxRuntime.Managed": "1.23.2"
+        }
+      },
       "Microsoft.ML.OnnxRuntime.Managed": {
         "type": "Transitive",
-        "resolved": "1.22.0",
-        "contentHash": "zlG3eY5mJnx1BhYAxRwpuHCGHzl3B+cY5/se0RmlVBw6Yh6QTGjPAXdjhlBIcw6BPFhgMn9lxWPE/U3Fvis+BQ==",
+        "resolved": "1.23.2",
+        "contentHash": "HtlQuzmVrqhnkmwfmkQ+2re8xPxtVmeLRQaYSJ3pXfzKs4b36+yBfa/LnDuzfX1bGcyWn/McKxmbY87TCAmo1Q==",
         "dependencies": {
           "System.Numerics.Tensors": "9.0.0"
         }
@@ -510,6 +536,7 @@
           "Google.Cloud.TextToSpeech.V1": "[3.17.0, )",
           "KokoroSharp.CPU": "[0.6.1, )",
           "Microsoft.CognitiveServices.Speech": "[1.41.1, )",
+          "Microsoft.ML.OnnxRuntime.Gpu": "[1.23.2, )",
           "NAudio": "[2.2.1, )",
           "OpenAI": "[2.8.0, )",
           "PiperSharp": "[1.0.6, )",

--- a/src/TextToTalk/Backends/Azure/AzureBackend.cs
+++ b/src/TextToTalk/Backends/Azure/AzureBackend.cs
@@ -1,9 +1,7 @@
 ﻿using Dalamud.Bindings.ImGui;
-using FFXIVClientStructs.FFXIV.Client.Game.UI;
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
-using TextToTalk.Backends.ElevenLabs;
 using static TextToTalk.Backends.Azure.AzureClient;
 
 namespace TextToTalk.Backends.Azure;
@@ -13,18 +11,19 @@ public class AzureBackend : VoiceBackend
     private readonly AzureBackendUI ui;
     private readonly AzureBackendUIModel uiModel;
     public List<VoiceDetails> voices;
+    private readonly LatencyTracker latencyTracker;
 
-    public AzureBackend(PluginConfiguration config, HttpClient http)
+    public AzureBackend(PluginConfiguration config, HttpClient http, LatencyTracker latencyTracker)
     {
         TitleBarColor = ImGui.ColorConvertU32ToFloat4(0xFFF96800);
 
         var lexiconManager = new DalamudLexiconManager();
         LexiconUtils.LoadFromConfigAzure(lexiconManager, config);
 
-        this.uiModel = new AzureBackendUIModel(config, lexiconManager);
+        this.uiModel = new AzureBackendUIModel(config, lexiconManager, latencyTracker);
         this.voices = this.uiModel.voices;
         this.ui = new AzureBackendUI(this.uiModel, config, lexiconManager, http, this);
-
+        this.latencyTracker = latencyTracker;
     }
 
     public override void DrawStyles(IConfigUIDelegates helpers)

--- a/src/TextToTalk/Backends/Azure/AzureBackendUIModel.cs
+++ b/src/TextToTalk/Backends/Azure/AzureBackendUIModel.cs
@@ -16,6 +16,8 @@ public class AzureBackendUIModel
     public List<VoiceDetails> voices;
     private AzureLoginInfo loginInfo;
 
+    private readonly LatencyTracker latencyTracker;
+
     /// <summary>
     /// Gets the currently-instantiated Azure client instance.
     /// </summary>
@@ -31,13 +33,14 @@ public class AzureBackendUIModel
     /// </summary>
     public IReadOnlyList<VoiceDetails> Voices => this.voices;
 
-    public AzureBackendUIModel(PluginConfiguration config, LexiconManager lexiconManager)
+    public AzureBackendUIModel(PluginConfiguration config, LexiconManager lexiconManager, LatencyTracker latencyTracker)
     {
         this.config = config;
         this.lexiconManager = lexiconManager;
         this.voices = new List<VoiceDetails>();
 
         this.loginInfo = new AzureLoginInfo();
+        this.latencyTracker = latencyTracker;
         var credentials = AzureCredentialManager.LoadCredentials();
         if (credentials != null)
         {
@@ -97,7 +100,7 @@ public class AzureBackendUIModel
         try
         {
             DetailedLog.Info($"Logging into Azure region {this.loginInfo.Region}");
-            Azure = new AzureClient(this.loginInfo.SubscriptionKey, this.loginInfo.Region, this.lexiconManager, this.config);
+            Azure = new AzureClient(this.loginInfo.SubscriptionKey, this.loginInfo.Region, this.lexiconManager, this.config, this.latencyTracker);
             // This should throw an exception if the login failed
             this.voices = Azure.GetVoicesWithStyles();
             return true;

--- a/src/TextToTalk/Backends/Azure/AzureClient.cs
+++ b/src/TextToTalk/Backends/Azure/AzureClient.cs
@@ -1,10 +1,12 @@
-﻿using System;
+﻿using Microsoft.CognitiveServices.Speech;
+using Microsoft.CognitiveServices.Speech.Audio;
+using Serilog;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CognitiveServices.Speech;
-using Microsoft.CognitiveServices.Speech.Audio;
 using TextToTalk.Lexicons;
 
 namespace TextToTalk.Backends.Azure;
@@ -13,16 +15,17 @@ public class AzureClient : IDisposable
 {
     private readonly SpeechConfig speechConfig;
     private readonly SpeechSynthesizer synthesizer;
-    private readonly StreamSoundQueue soundQueue;
+    private readonly StreamingSoundQueue soundQueue;
     private readonly LexiconManager lexiconManager;
     private readonly PluginConfiguration config;
+    private CancellationTokenSource? _ttsCts;
 
     public AzureClient(string subscriptionKey, string region, LexiconManager lexiconManager, PluginConfiguration config)
     {
         var audioConfig = AudioConfig.FromWavFileOutput("NUL");
         this.speechConfig = SpeechConfig.FromSubscription(subscriptionKey, region);
         this.synthesizer = new SpeechSynthesizer(speechConfig, audioConfig);
-        this.soundQueue = new StreamSoundQueue(config);
+        this.soundQueue = new StreamingSoundQueue(config);
         this.lexiconManager = lexiconManager;
     }
 
@@ -61,6 +64,10 @@ public class AzureClient : IDisposable
 
     public async Task Say(string? voice, int playbackRate, float volume, TextSource source, string text, string style)
     {
+        _ttsCts?.Cancel();
+        _ttsCts = new CancellationTokenSource();
+        var token = _ttsCts.Token;
+
         var ssml = this.lexiconManager.MakeSsml(
             text,
             style,
@@ -68,26 +75,41 @@ public class AzureClient : IDisposable
             langCode: "en-US",
             playbackRate: playbackRate,
             includeSpeakAttributes: true);
-        DetailedLog.Verbose(ssml);
 
-        var res = await this.synthesizer.SpeakSsmlAsync(ssml);
+            // LOW LATENCY PATH: Start speaking and stream chunks immediately
+            speechConfig.SetSpeechSynthesisOutputFormat(SpeechSynthesisOutputFormat.Raw16Khz16BitMonoPcm);
+            using var result = await this.synthesizer.StartSpeakingSsmlAsync(ssml);
+            using var audioDataStream = AudioDataStream.FromResult(result);
 
-        HandleResult(res);
+            byte[] buffer = new byte[4096];
+            uint bytesRead;
+            while ((bytesRead = audioDataStream.ReadData(buffer)) > 0)
+            {
+                if (token.IsCancellationRequested) break;
+                // Create a copy of the buffer for the specific chunk
+                var chunk = new byte[bytesRead];
+                Buffer.BlockCopy(buffer, 0, chunk, 0, (int)bytesRead);
 
-        var soundStream = new MemoryStream(res.AudioData);
-        soundStream.Seek(0, SeekOrigin.Begin);
+                var chunkStream = new MemoryStream(chunk);
+                this.soundQueue.EnqueueSound(chunkStream, source, volume, StreamFormat.Azure, null);
+            }
+            
+        }
 
-        this.soundQueue.EnqueueSound(soundStream, source, StreamFormat.Wave, volume);
-    }
 
     public Task CancelAllSounds()
     {
+        //this.synthesizer.Dispose();
+        this.soundQueue.CancelAllSounds();
+        this.soundQueue.StopHardware();
         this.soundQueue.CancelAllSounds();
         return Task.CompletedTask;
     }
 
     public Task CancelFromSource(TextSource source)
     {
+        this.synthesizer.StopSpeakingAsync();
+        this.soundQueue.StopHardware();
         this.soundQueue.CancelFromSource(source);
         return Task.CompletedTask;
     }
@@ -126,6 +148,7 @@ public class AzureClient : IDisposable
     public void Dispose()
     {
         this.synthesizer?.Dispose();
+        this.soundQueue?.Dispose();
         this.soundQueue?.Dispose();
     }
 }

--- a/src/TextToTalk/Backends/Azure/AzureClient.cs
+++ b/src/TextToTalk/Backends/Azure/AzureClient.cs
@@ -108,7 +108,7 @@ public class AzureClient : IDisposable
 
             var chunkStream = new MemoryStream(chunk);
             long? timestampToPass = methodStart;
-            soundQueue.EnqueueSound(chunkStream, source, volume, StreamFormat.Azure, null, timestampToPass);
+            soundQueue.EnqueueSound(chunkStream, source, volume, StreamFormat.Wave16K, null, timestampToPass);
 
         }
     }
@@ -149,7 +149,6 @@ public class AzureClient : IDisposable
     public void Dispose()
     {
         this.synthesizer?.Dispose();
-        this.soundQueue?.Dispose();
         this.soundQueue?.Dispose();
     }
 }

--- a/src/TextToTalk/Backends/Azure/AzureClient.cs
+++ b/src/TextToTalk/Backends/Azure/AzureClient.cs
@@ -27,7 +27,7 @@ public class AzureClient : IDisposable
     private readonly PluginConfiguration config;
     private CancellationTokenSource? _ttsCts;
 
-    public AzureClient(string subscriptionKey, string region, LexiconManager lexiconManager, PluginConfiguration config)
+    public AzureClient(string subscriptionKey, string region, LexiconManager lexiconManager, PluginConfiguration config, LatencyTracker latencyTracker)
     {
         _apiKey = subscriptionKey;
         _endpoint = $"https://{region}.tts.speech.microsoft.com/cognitiveservices/v1";
@@ -36,7 +36,7 @@ public class AzureClient : IDisposable
         _httpClient.DefaultRequestHeaders.Add("Ocp-Apim-Subscription-Key", _apiKey);
         _httpClient.DefaultRequestHeaders.Add("User-Agent", "TextToTalkApp");
 
-        soundQueue = new StreamingSoundQueue(config);
+        soundQueue = new StreamingSoundQueue(config, latencyTracker);
         _lexiconManager = lexiconManager;
         speechConfig = SpeechConfig.FromSubscription(subscriptionKey, region);
         speechConfig.SetSpeechSynthesisOutputFormat(SpeechSynthesisOutputFormat.Raw16Khz16BitMonoPcm);

--- a/src/TextToTalk/Backends/BackendUI.cs
+++ b/src/TextToTalk/Backends/BackendUI.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Dalamud.Bindings.ImGui;
 using TextToTalk.UI;
+using TextToTalk.UI.Windows;
 
 namespace TextToTalk.Backends;
 
@@ -142,5 +143,39 @@ public static class BackendUI
 
         ImGui.EndCombo();
         return didPresetsChange;
+    }
+    public static bool ImGuiStylesCombo(string label, string previewText, SortedSet<int> selectedIndices, List<string> styles)
+    {
+        // Use the passed-in string, or a placeholder if it's empty
+        string displayValue = !string.IsNullOrEmpty(previewText) ? previewText : "None selected";
+
+        bool didChange = false;
+
+        // The second parameter of BeginCombo controls what is shown in the closed box
+        if (ImGui.BeginCombo(label, displayValue))
+        {
+            for (int i = 0; i < styles.Count; i++)
+            {
+                bool isSelected = selectedIndices.Contains(i);
+
+                // Use Selectable with DontClosePopups for multi-select
+                if (ImGui.Selectable(styles[i], isSelected, ImGuiSelectableFlags.DontClosePopups))
+                {
+                    if (!isSelected)
+                        selectedIndices.Add(i);
+                    else
+                        selectedIndices.Remove(i);
+
+                    didChange = true;
+                }
+
+                if (isSelected)
+                    ImGui.SetItemDefaultFocus();
+            }
+
+            ImGui.EndCombo();
+        }
+
+        return didChange;
     }
 }

--- a/src/TextToTalk/Backends/ElevenLabs/ElevenLabsBackend.cs
+++ b/src/TextToTalk/Backends/ElevenLabs/ElevenLabsBackend.cs
@@ -13,10 +13,11 @@ public class ElevenLabsBackend : VoiceBackend
     private readonly ElevenLabsBackendUIModel uiModel;
     private readonly INotificationService notificationService;
     private readonly PluginConfiguration config;
+    private readonly LatencyTracker latencyTracker;
 
-    public ElevenLabsBackend(PluginConfiguration config, HttpClient http, INotificationService notificationService)
+    public ElevenLabsBackend(PluginConfiguration config, HttpClient http, INotificationService notificationService, LatencyTracker latencyTracker)
     {
-        this.uiModel = new ElevenLabsBackendUIModel(config, http);
+        this.uiModel = new ElevenLabsBackendUIModel(config, http, latencyTracker);
         this.ui = new ElevenLabsBackendUI(uiModel, config, this);
         this.notificationService = notificationService;
         this.config = config;

--- a/src/TextToTalk/Backends/ElevenLabs/ElevenLabsBackend.cs
+++ b/src/TextToTalk/Backends/ElevenLabs/ElevenLabsBackend.cs
@@ -67,11 +67,21 @@ public class ElevenLabsBackend : VoiceBackend
     public override void CancelAllSpeech()
     {
         this.uiModel.SoundQueue.CancelAllSounds();
+        if (this.uiModel.ElevenLabs._TtsCts != null)
+        {
+            this.uiModel.ElevenLabs._TtsCts.Cancel();
+        }
+        this.uiModel.SoundQueue.StopHardware();
     }
 
     public override void CancelSay(TextSource source)
     {
         this.uiModel.SoundQueue.CancelFromSource(source);
+        if (this.uiModel.ElevenLabs._TtsCts != null)
+        {
+            this.uiModel.ElevenLabs._TtsCts.Cancel();
+        }
+        this.uiModel.SoundQueue.StopHardware();
     }
 
     public override void DrawSettings(IConfigUIDelegates helpers)

--- a/src/TextToTalk/Backends/ElevenLabs/ElevenLabsBackendUI.cs
+++ b/src/TextToTalk/Backends/ElevenLabs/ElevenLabsBackendUI.cs
@@ -150,18 +150,21 @@ public class ElevenLabsBackendUI
             var modelDescriptionsList = modelDescriptions.Values.Select(v => v.Items.First()).ToList();
             var selectedItemIndex = modelIdList.IndexOf(currentVoicePreset.ModelId);
 
-            string modelPreviewName = "";
-            if (selectedItemIndex != -1)
+            string modelPreviewName = "Select a model...";
+            bool previewHasStyles = false;
+
+            if (selectedItemIndex >= 0 && selectedItemIndex < modelDescriptionsList.Count)
             {
                 var selectedItem = modelDescriptionsList[selectedItemIndex];
                 modelPreviewName = $"{selectedItem.ModelId} || Cost Multiplier: {selectedItem.ModelRates["character_cost_multiplier"]}";
+
                 if (currentVoicePreset.ModelId == "eleven_v3")
                 {
                     modelPreviewName += " [Styles Available]";
+                    previewHasStyles = true;
                 }
             }
 
-            bool previewHasStyles = modelIdList[selectedItemIndex] == "eleven_v3";
             string previewName = voiceIndex >= 0 ? $"{modelIdList[selectedItemIndex]} || Cost Multiplier: {modelDescriptionsList[selectedItemIndex].ModelRates["character_cost_multiplier"]}" : "Select a model...";
 
             if (ImGui.BeginCombo($"Models##{MemoizedId.Create()}", "", ImGuiComboFlags.HeightLarge))

--- a/src/TextToTalk/Backends/ElevenLabs/ElevenLabsBackendUIModel.cs
+++ b/src/TextToTalk/Backends/ElevenLabs/ElevenLabsBackendUIModel.cs
@@ -44,9 +44,9 @@ public class ElevenLabsBackendUIModel : IDisposable
     public IReadOnlyDictionary<string, IReadOnlyList<ElevenLabsVoice>> Voices { get; private set; }
 
     public IReadOnlyDictionary<string, (IReadOnlyList<ElevenLabsModel> Items, Dictionary<string, double>? Rates)> Models { get; private set; }
-    public ElevenLabsBackendUIModel(PluginConfiguration config, HttpClient http)
+    public ElevenLabsBackendUIModel(PluginConfiguration config, HttpClient http, LatencyTracker latencyTracker)
     {
-        SoundQueue = new StreamingSoundQueue(config);
+        SoundQueue = new StreamingSoundQueue(config, latencyTracker);
         ElevenLabs = new ElevenLabsClient(SoundQueue, http);
         this.config = config;
         this.getUserSubscriptionInfoImmediately = new ReactiveProperty<long>(0);

--- a/src/TextToTalk/Backends/ElevenLabs/ElevenLabsBackendUIModel.cs
+++ b/src/TextToTalk/Backends/ElevenLabs/ElevenLabsBackendUIModel.cs
@@ -21,7 +21,7 @@ public class ElevenLabsBackendUIModel : IDisposable
     /// <summary>
     /// Gets the sound playback queue.
     /// </summary>
-    public StreamSoundQueue SoundQueue { get; }
+    public StreamingSoundQueue SoundQueue { get; }
 
     /// <summary>
     /// Gets the currently-instantiated ElevenLabs client instance.
@@ -46,7 +46,7 @@ public class ElevenLabsBackendUIModel : IDisposable
     public IReadOnlyDictionary<string, (IReadOnlyList<ElevenLabsModel> Items, Dictionary<string, double>? Rates)> Models { get; private set; }
     public ElevenLabsBackendUIModel(PluginConfiguration config, HttpClient http)
     {
-        SoundQueue = new StreamSoundQueue(config);
+        SoundQueue = new StreamingSoundQueue(config);
         ElevenLabs = new ElevenLabsClient(SoundQueue, http);
         this.config = config;
         this.getUserSubscriptionInfoImmediately = new ReactiveProperty<long>(0);

--- a/src/TextToTalk/Backends/GoogleCloud/GoogleCloudBackend.cs
+++ b/src/TextToTalk/Backends/GoogleCloud/GoogleCloudBackend.cs
@@ -8,10 +8,11 @@ public class GoogleCloudBackend : VoiceBackend
     private readonly GoogleCloudClient client;
     private readonly StreamingSoundQueue soundQueue;
     private readonly GoogleCloudBackendUI ui;
+    private readonly LatencyTracker latencyTracker;
 
-    public GoogleCloudBackend(PluginConfiguration config)
+    public GoogleCloudBackend(PluginConfiguration config, LatencyTracker latencyTracker)
     {
-        soundQueue = new StreamingSoundQueue(config);
+        soundQueue = new StreamingSoundQueue(config, latencyTracker);
         client = new GoogleCloudClient(soundQueue, config.GoogleCreds);
         ui = new GoogleCloudBackendUI(config, client, this);
     }

--- a/src/TextToTalk/Backends/GoogleCloud/GoogleCloudBackend.cs
+++ b/src/TextToTalk/Backends/GoogleCloud/GoogleCloudBackend.cs
@@ -26,7 +26,7 @@ public class GoogleCloudBackend : VoiceBackend
         if (request.Voice is not GoogleCloudVoicePreset voicePreset)
             throw new InvalidOperationException("Invalid voice preset provided.");
 
-        _ = client.Say(voicePreset.Locale, voicePreset.VoiceName, voicePreset.PlaybackRate, voicePreset.Volume, request.Source,
+        _ = client.Say(voicePreset.Locale, voicePreset.VoiceName, voicePreset.SampleRate, voicePreset.PlaybackRate, voicePreset.Volume, request.Source,
             request.Text);
     }
 

--- a/src/TextToTalk/Backends/GoogleCloud/GoogleCloudBackendUI.cs
+++ b/src/TextToTalk/Backends/GoogleCloud/GoogleCloudBackendUI.cs
@@ -102,25 +102,8 @@ public class GoogleCloudBackendUI
             ImGui.EndCombo();
         }
 
-        var validSampleRates = new[] { "8000", "16000", "22050", "24000" };
-        var sampleRate = currentVoicePreset.SampleRate.ToString();
-        var sampleRateIndex = Array.IndexOf(validSampleRates, sampleRate);
-        if (ImGui.Combo($"Sample rate##{MemoizedId.Create()}", ref sampleRateIndex, validSampleRates,
-                validSampleRates.Length))
-        {
-            currentVoicePreset.SampleRate = int.Parse(validSampleRates[sampleRateIndex]);
-            this.config.Save();
-        }
-
-        var pitch = currentVoicePreset.Pitch ?? 0;
-        if (ImGui.SliderFloat($"Pitch##{MemoizedId.Create()}", ref pitch, -10f, 10f, "%.2fx"))
-        {
-            currentVoicePreset.Pitch = pitch;
-            config.Save();
-        }
-
         var playbackRate = currentVoicePreset.PlaybackRate ?? 1;
-        if (ImGui.SliderFloat($"Playback rate##{MemoizedId.Create()}", ref playbackRate, 0.25f, 4f, "%.2fx"))
+        if (ImGui.SliderFloat($"Playback rate##{MemoizedId.Create()}", ref playbackRate, 0.25f, 2f, "%.2fx"))
         {
             currentVoicePreset.PlaybackRate = playbackRate;
             config.Save();

--- a/src/TextToTalk/Backends/GoogleCloud/GoogleCloudBackendUI.cs
+++ b/src/TextToTalk/Backends/GoogleCloud/GoogleCloudBackendUI.cs
@@ -101,6 +101,15 @@ public class GoogleCloudBackendUI
 
             ImGui.EndCombo();
         }
+        var validSampleRates = new[] { "8000", "16000", "22050", "24000" };
+        var sampleRate = currentVoicePreset.SampleRate.ToString();
+        var sampleRateIndex = Array.IndexOf(validSampleRates, sampleRate);
+        if (ImGui.Combo($"Sample rate##{MemoizedId.Create()}", ref sampleRateIndex, validSampleRates,
+                validSampleRates.Length))
+        {
+            currentVoicePreset.SampleRate = int.Parse(validSampleRates[sampleRateIndex]);
+            this.config.Save();
+        }
 
         var playbackRate = currentVoicePreset.PlaybackRate ?? 1;
         if (ImGui.SliderFloat($"Playback rate##{MemoizedId.Create()}", ref playbackRate, 0.25f, 2f, "%.2fx"))

--- a/src/TextToTalk/Backends/GoogleCloud/GoogleCloudClient.cs
+++ b/src/TextToTalk/Backends/GoogleCloud/GoogleCloudClient.cs
@@ -1,9 +1,10 @@
+using Google.Cloud.TextToSpeech.V1;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
-using Google.Cloud.TextToSpeech.V1;
 using WebSocketSharp;
 
 namespace TextToTalk.Backends.GoogleCloud;
@@ -11,11 +12,13 @@ namespace TextToTalk.Backends.GoogleCloud;
 public class GoogleCloudClient
 {
     private TextToSpeechClient? client;
-    private readonly StreamSoundQueue? soundQueue;
+    private readonly StreamingSoundQueue? soundQueue;
     public Dictionary<string, dynamic>? Voices;
     public List<string>? Locales;
 
-    public GoogleCloudClient(StreamSoundQueue soundQueue, string pathToCredential)
+    public CancellationTokenSource? _TtsCts;
+
+    public GoogleCloudClient(StreamingSoundQueue soundQueue, string pathToCredential)
     {
         this.soundQueue = soundQueue;
         if (pathToCredential.IsNullOrEmpty()) return;
@@ -33,17 +36,24 @@ public class GoogleCloudClient
     public Dictionary<string, dynamic>? GetGoogleTextToSpeechVoices()
     {
         if (client == null) return new Dictionary<string, dynamic>();
+
+        // Fetch all available voices
         var response = client.ListVoices("");
 
         var fetchedVoices = new Dictionary<string, dynamic>();
 
         foreach (var voice in response.Voices)
         {
-            fetchedVoices.Add(voice.Name, new
+            // Filter: Only include voices with "Chirp3" or "Chirp-HD" in their name
+            // Rebranded "Journey" voices also now fall under "Chirp-HD"
+            if (voice.Name.Contains("Chirp3") || voice.Name.Contains("Chirp-HD"))
             {
-                Name = voice.Name,
-                Gender = voice.SsmlGender,
-            });
+                fetchedVoices.Add(voice.Name, new
+                {
+                    Name = voice.Name,
+                    Gender = voice.SsmlGender,
+                });
+            }
         }
 
         return fetchedVoices;
@@ -65,37 +75,76 @@ public class GoogleCloudClient
         return uniqueLocales.ToList().OrderBy(lang => lang).ToList();
     }
 
-    public async Task Say(string? locale, string? voice, int? sampleRate, float? pitch, float? speed, float volume, TextSource source,
-        string text)
+    public async Task Say(string? locale, string? voice, float? speed, float volume, TextSource source, string text)
     {
-        if (client == null || soundQueue == null || locale == null)
+        if (client == null || soundQueue == null || locale == null) return;
+
+        if (_TtsCts != null)
         {
-            return;
+            _TtsCts?.Cancel();
+            _TtsCts?.Dispose();
         }
 
-        var request = new SynthesizeSpeechRequest
+        _TtsCts = new CancellationTokenSource();
+        var ct = _TtsCts.Token;
+
+        try
         {
-            Input = new SynthesisInput { Text = text },
-            Voice = new VoiceSelectionParams
+            // 1. Open the stream with the cancellation token
+            using var streamingCall = client.StreamingSynthesize();
+
+            // 2. FIRST request: Configuration ONLY
+            var configRequest = new StreamingSynthesizeRequest
             {
-                LanguageCode = locale,
-                Name = voice ?? "en-US-Wavenet-A"
-            },
-            AudioConfig = new AudioConfig
+                StreamingConfig = new StreamingSynthesizeConfig
+                {
+                    Voice = new VoiceSelectionParams
+                    {
+                        LanguageCode = locale,
+                        Name = voice ?? "en-US-Chirp3-HD-Puff-A"
+                    },
+                    StreamingAudioConfig = new StreamingAudioConfig
+                    {
+                        // Linear16 is the 2026 standard for Chirp 3 HD PCM streaming
+                        AudioEncoding = AudioEncoding.Pcm,
+                        SampleRateHertz = 24000,
+                        SpeakingRate = speed ?? 1.0f,
+                    }
+                }
+            };
+
+            // Pass token to WriteAsync to stop sending if cancelled
+            await streamingCall.WriteAsync(configRequest);
+
+            // 3. SECOND request: Input Text ONLY
+            await streamingCall.WriteAsync(new StreamingSynthesizeRequest
             {
-                AudioEncoding = AudioEncoding.Mp3,
-                SampleRateHertz = sampleRate ?? 22050,
-                Pitch = pitch ?? 0,
-                SpeakingRate = speed ?? 1.0f,
-                VolumeGainDb = volume
+                Input = new StreamingSynthesisInput { Text = text }
+            });
+
+            await streamingCall.WriteCompleteAsync();
+
+            // 4. Process the response stream with the cancellation token
+            // Use WithCancellation to properly dispose of the enumerator on cancel
+            await foreach (var response in streamingCall.GetResponseStream().WithCancellation(ct))
+            {
+                if (response.AudioContent.Length > 0)
+                {
+                    var chunkStream = new MemoryStream(response.AudioContent.ToByteArray());
+
+                    // Note: Linear16 audio is typically handled as StreamFormat.Pcm 
+                    // but matches Wave if your queue expects raw headerless bytes.
+                    soundQueue.EnqueueSound(chunkStream, source, volume, StreamFormat.Wave, null);
+                }
             }
-        };
-
-        var response = await client.SynthesizeSpeechAsync(request);
-
-        MemoryStream mp3Stream = new MemoryStream(response.AudioContent.ToByteArray());
-        mp3Stream.Seek(0, SeekOrigin.Begin);
-
-        soundQueue.EnqueueSound(mp3Stream, source, StreamFormat.Mp3, volume);
+        }
+        catch (OperationCanceledException)
+        {
+            // Handle normal cancellation (e.g., stopping the voice)
+        }
+        catch (Grpc.Core.RpcException ex) when (ex.StatusCode == Grpc.Core.StatusCode.Cancelled)
+        {
+            // Handle gRPC specific cancellation
+        }
     }
 }

--- a/src/TextToTalk/Backends/GoogleCloud/GoogleCloudVoicePreset.cs
+++ b/src/TextToTalk/Backends/GoogleCloud/GoogleCloudVoicePreset.cs
@@ -6,6 +6,8 @@ public class GoogleCloudVoicePreset : VoicePreset
 {
     public float Volume { get; set; }
 
+    public int? SampleRate { get; set; }
+
     // 0.25 - 2.0 (default 1.0)
     public float? PlaybackRate { get; set; }
 
@@ -19,6 +21,7 @@ public class GoogleCloudVoicePreset : VoicePreset
     {
         Volume = 1.0f;
         PlaybackRate = 1.0f;
+        SampleRate = 22050;
         Locale = "en-US";
         VoiceName = "en-US-Chirp-HD-D";
         Gender = "Male";

--- a/src/TextToTalk/Backends/GoogleCloud/GoogleCloudVoicePreset.cs
+++ b/src/TextToTalk/Backends/GoogleCloud/GoogleCloudVoicePreset.cs
@@ -4,14 +4,9 @@ namespace TextToTalk.Backends.GoogleCloud;
 
 public class GoogleCloudVoicePreset : VoicePreset
 {
-    public int? SampleRate { get; set; }
-
-    // -20.0 - 20.0 is theoretical max, but it's lowered to work better with sliders (default 0.0)
-    public float? Pitch { get; set; }
-
     public float Volume { get; set; }
 
-    // 0.25 - 4.0 (default 1.0)
+    // 0.25 - 2.0 (default 1.0)
     public float? PlaybackRate { get; set; }
 
     public string? Locale { get; set; }
@@ -22,12 +17,10 @@ public class GoogleCloudVoicePreset : VoicePreset
 
     public override bool TrySetDefaultValues()
     {
-        SampleRate = 22050;
-        Pitch = 0.0f;
         Volume = 1.0f;
         PlaybackRate = 1.0f;
         Locale = "en-US";
-        VoiceName = "en-US-Wavenet-D";
+        VoiceName = "en-US-Chirp-HD-D";
         Gender = "Male";
         EnabledBackend = TTSBackend.GoogleCloud;
         return true;

--- a/src/TextToTalk/Backends/Kokoro/KokoroBackend.cs
+++ b/src/TextToTalk/Backends/Kokoro/KokoroBackend.cs
@@ -1,15 +1,16 @@
+using Dalamud.Bindings.ImGui;
+using Dalamud.Game;
+using KokoroSharp;
+using KokoroSharp.Core;
+using KokoroSharp.Processing;
 using System;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Net.Http;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
-using Dalamud.Game;
-using Dalamud.Bindings.ImGui;
-using KokoroSharp;
-using KokoroSharp.Core;
-using KokoroSharp.Processing;
 
 namespace TextToTalk.Backends.Kokoro;
 
@@ -105,6 +106,8 @@ public class KokoroBackend : VoiceBackend
 
     public void Say(string text, KokoroVoicePreset voicePreset, TextSource source, ClientLanguage language)
     {
+        long methodStart = Stopwatch.GetTimestamp();
+        long? timestampToPass = methodStart;
         if (!TryGetModel(out _))
         {
             return;
@@ -120,7 +123,7 @@ public class KokoroBackend : VoiceBackend
         }
 
         // TODO: apply lexicon once KokoroSharp supports it
-        soundQueue.EnqueueSound(new(text, voice, voicePreset.Speed ?? 1f, voicePreset.Volume ?? 0.6f, source, language));
+        soundQueue.EnqueueSound(new(text, voice, voicePreset.Speed ?? 1f, voicePreset.Volume ?? 0.6f, source, language, timestampToPass));
     }
 
     public override void CancelAllSpeech()

--- a/src/TextToTalk/Backends/Kokoro/KokoroBackend.cs
+++ b/src/TextToTalk/Backends/Kokoro/KokoroBackend.cs
@@ -21,18 +21,20 @@ public class KokoroBackend : VoiceBackend
     private readonly KokoroBackendUI ui;
     private readonly Task<KokoroModel> modelTask;
     private readonly CancellationTokenSource cts = new();
+    private readonly LatencyTracker latencyTracker;
 
-    public KokoroBackend(PluginConfiguration config)
+    public KokoroBackend(PluginConfiguration config, LatencyTracker latencyTracker)
     {
         ui = new KokoroBackendUI(config, this);
 
         Tokenizer.eSpeakNGPath = Path.Join(config.GetPluginAssemblyDirectory(), "espeak");
 
         modelTask = GetModelAsync(config);
-        soundQueue = new KokoroSoundQueue(config, modelTask);
+        soundQueue = new KokoroSoundQueue(config, modelTask, latencyTracker);
 
         KokoroVoiceManager.LoadVoicesFromPath(Path.Join(config.GetPluginAssemblyDirectory(), "voices"));
         DetailedLog.Info($"Kokoro voices loaded: {KokoroVoiceManager.Voices.Count} voices available.");
+        this.latencyTracker = latencyTracker;
     }
 
     /// <summary>

--- a/src/TextToTalk/Backends/Kokoro/KokoroBackend.cs
+++ b/src/TextToTalk/Backends/Kokoro/KokoroBackend.cs
@@ -165,10 +165,6 @@ public class KokoroBackend : VoiceBackend
         cts.Cancel();
         if (disposing)
         {
-            if (TryGetModel(out var model))
-            {
-                model.Dispose();
-            }
             soundQueue.Dispose();
         }
     }

--- a/src/TextToTalk/Backends/Kokoro/KokoroSoundQueue.cs
+++ b/src/TextToTalk/Backends/Kokoro/KokoroSoundQueue.cs
@@ -20,14 +20,16 @@ public class KokoroSoundQueue : SoundQueue<KokoroSourceQueueItem>
     private readonly object soundLock = new();
     private readonly PluginConfiguration config;
     private readonly Task<KokoroModel> modelTask;
+    private readonly LatencyTracker latencyTracker;
 
     private WasapiOut? soundOut;
     private BufferedWaveProvider? bufferedProvider;
 
-    public KokoroSoundQueue(PluginConfiguration config, Task<KokoroModel> modelTask)
+    public KokoroSoundQueue(PluginConfiguration config, Task<KokoroModel> modelTask, LatencyTracker latencyTracker)
     {
         this.config = config;
         this.modelTask = modelTask;
+        this.latencyTracker = latencyTracker;
     }
 
     private bool TryGetModel([NotNullWhen(true)] out KokoroModel? model)
@@ -92,6 +94,7 @@ public class KokoroSoundQueue : SoundQueue<KokoroSourceQueueItem>
                         if (nextItem.StartTime.HasValue)
                         {
                             var elapsed = Stopwatch.GetElapsedTime(nextItem.StartTime.Value);
+                            this.latencyTracker.AddLatency(elapsed.TotalMilliseconds);
                             Log.Debug("Total Latency (Say -> Play): {Ms}", elapsed.TotalMilliseconds);
                         }
                         this.soundOut.Play();

--- a/src/TextToTalk/Backends/OpenAI/OpenAiBackend.cs
+++ b/src/TextToTalk/Backends/OpenAI/OpenAiBackend.cs
@@ -37,8 +37,7 @@ public class OpenAiBackend : VoiceBackend
         {
             try
             {
-                Log.Information($"Voice Style = {voicePreset.Style}");
-                await this.uiModel.OpenAi.Say(request.Text, voicePreset.Model, voicePreset.VoiceName, !string.IsNullOrWhiteSpace(request.Style) ? request.Style : (voicePreset.Style ?? string.Empty), 1.0f, voicePreset.Volume);
+                await this.uiModel.OpenAi.Say(request.Text, voicePreset.Model, request.Source, voicePreset.VoiceName, !string.IsNullOrWhiteSpace(request.Style) ? request.Style : (voicePreset.Style ?? string.Empty), 1.0f, voicePreset.Volume);
             }
             catch (OpenAiUnauthorizedException e)
             {

--- a/src/TextToTalk/Backends/OpenAI/OpenAiBackend.cs
+++ b/src/TextToTalk/Backends/OpenAI/OpenAiBackend.cs
@@ -15,10 +15,11 @@ public class OpenAiBackend : VoiceBackend
     private readonly OpenAiBackendUI ui;
     private readonly OpenAiBackendUIModel uiModel;
     private readonly INotificationService notificationService;
+    private readonly LatencyTracker latencyTracker;
 
-    public OpenAiBackend(PluginConfiguration config, HttpClient http, INotificationService notificationService)
+    public OpenAiBackend(PluginConfiguration config, HttpClient http, INotificationService notificationService, LatencyTracker latencyTracker)
     {
-        this.uiModel = new OpenAiBackendUIModel(config, http);
+        this.uiModel = new OpenAiBackendUIModel(config, http, latencyTracker);
         this.ui = new OpenAiBackendUI(uiModel, config, this);
         this.notificationService = notificationService;
     }

--- a/src/TextToTalk/Backends/OpenAI/OpenAiBackend.cs
+++ b/src/TextToTalk/Backends/OpenAI/OpenAiBackend.cs
@@ -69,27 +69,22 @@ public class OpenAiBackend : VoiceBackend
 
     public override void CancelAllSpeech()
     {
-        //Cancel at the queue
         this.uiModel.SoundQueue.CancelAllSounds();
 
-        //Cancel at Speech Generation
         if (uiModel.OpenAi._ttsCts != null)
         {
             uiModel.OpenAi._ttsCts.Cancel();
             uiModel.OpenAi._ttsCts.Dispose();
             uiModel.OpenAi._ttsCts = null;
         }
-        //Cancel at Playback
         this.uiModel.SoundQueue.StopHardware();
         
     }
 
     public override void CancelSay(TextSource source)
     {
-        //Cancel at the queue
         this.uiModel.SoundQueue.CancelFromSource(source);
 
-        //Cancel at Speech Generation
         if (uiModel.OpenAi._ttsCts != null)
         {
             uiModel.OpenAi._ttsCts.Cancel();
@@ -97,7 +92,6 @@ public class OpenAiBackend : VoiceBackend
             uiModel.OpenAi._ttsCts = null;
         }
 
-        //Cancel at Playback
         if (uiModel.SoundQueue._ttsCts != null)
         {
             uiModel.OpenAi._ttsCts.Cancel();

--- a/src/TextToTalk/Backends/OpenAI/OpenAiBackendUI.cs
+++ b/src/TextToTalk/Backends/OpenAI/OpenAiBackendUI.cs
@@ -122,33 +122,25 @@ public class OpenAiBackendUI
         if (currentVoicePreset.Model == null) return;
 
         var currentModel = OpenAiClient.Models.First(x => x.ModelName == currentVoicePreset.Model);
-        // 1. Determine what to display in the preview (the value corresponding to the current key)
         if (!currentModel.Voices.TryGetValue(currentVoicePreset.VoiceName ?? "", out var currentPreviewName))
         {
-            // Fallback if current key is invalid or null
             currentVoicePreset.VoiceName = currentModel.Voices.Keys.First();
             currentPreviewName = currentModel.Voices[currentVoicePreset.VoiceName];
             config.Save();
         }
 
-        // 2. Start the Combo Box with the Descriptive Value as the preview
         if (ImGui.BeginCombo($"Voice##{MemoizedId.Create()}", currentPreviewName))
         {
             foreach (var voice in currentModel.Voices)
             {
-                // voice.Key is "alloy", "ash", etc.
-                // voice.Value is "Alloy (Neutral & Balanced)", etc.
                 bool isSelected = (currentVoicePreset.VoiceName == voice.Key);
 
-                // 3. Display the descriptive Value to the user
                 if (ImGui.Selectable(voice.Value, isSelected))
                 {
-                    // 4. Update config with the underlying Key
                     currentVoicePreset.VoiceName = voice.Key;
                     config.Save();
                 }
 
-                // Standard ImGui accessibility: set focus to the selected item
                 if (isSelected)
                 {
                     ImGui.SetItemDefaultFocus();
@@ -189,17 +181,14 @@ public class OpenAiBackendUI
             }
             else
             {
-                // 1. Generate the preview text directly from the set
                 string previewText = currentVoicePreset.Styles.Count > 0
                     ? string.Join(", ", currentVoicePreset.Styles)
                     : "None selected";
 
-                // 2. Open the Combo
                 if (ImGui.BeginCombo($"Voice Style##{MemoizedId.Create()}", previewText))
                 {
                     foreach (var styleName in config.CustomVoiceStyles)
                     {
-                        // Check if this style is currently in our preset's set
                         bool isSelected = currentVoicePreset.Styles.Contains(styleName);
 
                         if (ImGui.Selectable(styleName, isSelected, ImGuiSelectableFlags.DontClosePopups))
@@ -209,9 +198,6 @@ public class OpenAiBackendUI
                             else
                                 currentVoicePreset.Styles.Add(styleName);
 
-                            // 3. Save immediately
-                            // Because 'Styles' is a reference type inside the preset, 
-                            // the save/reload won't "wipe" your local UI state anymore.
                             currentVoicePreset.SyncStringFromSet();
                             this.config.Save();
                         }

--- a/src/TextToTalk/Backends/OpenAI/OpenAiBackendUIModel.cs
+++ b/src/TextToTalk/Backends/OpenAI/OpenAiBackendUIModel.cs
@@ -37,24 +37,10 @@ public class OpenAiBackendUIModel
     /// Gets the valid voices for the current voice engine.
     /// NOTE: Currently there is no endpoint which provides this information for OpenAI.
     /// </summary>
-    // public IReadOnlyDictionary<string, IReadOnlyList<string>> Voices { get; private set; }
 
     public OpenAiBackendUIModel(PluginConfiguration config, HttpClient http, LatencyTracker latencyTracker)
     {
-        SoundQueue = new StreamingSoundQueue(config, latencyTracker);
-        var credentials = OpenAiCredentialManager.LoadCredentials();
-        if (credentials != null)
-        {
-            apiKey = (credentials.Password);
-        }
-        //RawStreamingSoundQueue = new RawStreamingSoundQueue(config);
-        OpenAi = new OpenAiClient(SoundQueue, apiKey);
         this.config = config;
-        this.apiKey = "";
-
-        // this.Voices = new Dictionary<string, IReadOnlyList<string>>();
-
-
     }
 
     /// <summary>

--- a/src/TextToTalk/Backends/OpenAI/OpenAiBackendUIModel.cs
+++ b/src/TextToTalk/Backends/OpenAI/OpenAiBackendUIModel.cs
@@ -39,9 +39,9 @@ public class OpenAiBackendUIModel
     /// </summary>
     // public IReadOnlyDictionary<string, IReadOnlyList<string>> Voices { get; private set; }
 
-    public OpenAiBackendUIModel(PluginConfiguration config, HttpClient http)
+    public OpenAiBackendUIModel(PluginConfiguration config, HttpClient http, LatencyTracker latencyTracker)
     {
-        SoundQueue = new StreamingSoundQueue(config);
+        SoundQueue = new StreamingSoundQueue(config, latencyTracker);
         var credentials = OpenAiCredentialManager.LoadCredentials();
         if (credentials != null)
         {

--- a/src/TextToTalk/Backends/OpenAI/OpenAiVoicePreset.cs
+++ b/src/TextToTalk/Backends/OpenAI/OpenAiVoicePreset.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json.Serialization;
 
 namespace TextToTalk.Backends.OpenAI;
@@ -13,8 +14,26 @@ public class OpenAiVoicePreset : VoicePreset
     public float? PlaybackRate { get; set; }
 
     [JsonPropertyName("OpenAIVoiceName")] public string? VoiceName { get; set; }
-    
-    public string? Style { get; set; }
+
+    public string? Style { get; set; } = "";
+
+    [JsonIgnore] public SortedSet<string> Styles { get; set; } = new SortedSet<string>();
+
+
+    public void SyncSetFromString()
+    {
+        Styles.Clear();
+        if (string.IsNullOrWhiteSpace(Style)) return;
+
+        foreach (var s in Style.Split(", "))
+            Styles.Add(s);
+    }
+
+    // Call this whenever the UI changes the Set to update the String
+    public void SyncStringFromSet()
+    {
+        Style = string.Join(", ", Styles);
+    }
 
     public override bool TrySetDefaultValues()
     {

--- a/src/TextToTalk/Backends/Piper/PiperBackend.cs
+++ b/src/TextToTalk/Backends/Piper/PiperBackend.cs
@@ -29,11 +29,12 @@ public class PiperBackend : VoiceBackend
 
     private Process? piperServerProcess;
     private readonly object processLock = new();
+    private readonly LatencyTracker latencyTracker;
 
     public string GetVoicesDir(PluginConfiguration config) =>
         Path.Combine(config.GetPluginConfigDirectory(), "piper", "voices");
 
-    public PiperBackend(PluginConfiguration config)
+    public PiperBackend(PluginConfiguration config, LatencyTracker latencyTracker)
     {
         this.ui = new PiperBackendUI(config, this);
 
@@ -48,8 +49,9 @@ public class PiperBackend : VoiceBackend
         });
 
         this.modelTask = LoadOrDownloadModelAsync(config);
-        this.soundQueue = new StreamingSoundQueue(config);
+        this.soundQueue = new StreamingSoundQueue(config, latencyTracker);
         this.config = config;
+        this.latencyTracker = latencyTracker;
     }
 
     public async Task<IDictionary<string, VoiceModel>> GetAvailableModels()

--- a/src/TextToTalk/Backends/Piper/PiperBackend.cs
+++ b/src/TextToTalk/Backends/Piper/PiperBackend.cs
@@ -59,7 +59,7 @@ public class PiperBackend : VoiceBackend
     }
     public static bool IsModelFileDownloaded(PluginConfiguration config)
     {
-        var piperExePath = Path.Combine(config.GetPluginConfigDirectory(), "piper", "piper.exe");
+        var piperExePath = Path.Combine(config.GetPluginConfigDirectory(), "piper", "piper", "piper.exe");
         return File.Exists(piperExePath);
     }
 

--- a/src/TextToTalk/Backends/Piper/PiperBackend.cs
+++ b/src/TextToTalk/Backends/Piper/PiperBackend.cs
@@ -279,9 +279,9 @@ public class PiperBackend : VoiceBackend
             // 8. Determine Audio Format
             var format = voicePreset.InternalName switch
             {
-                string name when name.EndsWith("low") => StreamFormat.PiperLow,
-                string name when name.EndsWith("high") => StreamFormat.PiperHigh,
-                _ => StreamFormat.Piper // Defaults to Medium/Standard
+                string name when name.EndsWith("low") => StreamFormat.Wave16K,
+                string name when name.EndsWith("high") => StreamFormat.Wave,
+                _ => StreamFormat.Wave22K // Defaults to Medium/Standard
             };
 
             // 9. Enqueue Stream

--- a/src/TextToTalk/Backends/Piper/PiperBackend.cs
+++ b/src/TextToTalk/Backends/Piper/PiperBackend.cs
@@ -1,0 +1,214 @@
+﻿using Dalamud.Bindings.ImGui;
+using Dalamud.Game;
+using PiperSharp;
+using PiperSharp.Models;
+using Serilog;
+using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using TextToTalk.Backends.Kokoro;
+using TextToTalk.Backends.Piper;
+
+namespace TextToTalk.Backends.Piper;
+
+public class PiperBackend : VoiceBackend
+{
+    private readonly PiperProvider piper;
+    private readonly PiperBackendUI ui;
+    private readonly StreamingSoundQueue soundQueue;
+    private readonly Task<VoiceModel> modelTask;
+    private readonly CancellationTokenSource cts = new();
+
+    private Process? piperServerProcess;
+
+    private string GetVoicesDir(PluginConfiguration config) =>
+        Path.Combine(config.GetPluginConfigDirectory(), "piper", "voices");
+
+    public PiperBackend(PluginConfiguration config)
+    {
+        ui = new PiperBackendUI(config, this);
+        string piperExe = Path.Join(config.GetPluginConfigDirectory(), "piper", "piper.exe");
+
+        piper = new PiperProvider(new PiperConfiguration()
+        {
+            ExecutableLocation = piperExe,
+            WorkingDirectory = Path.GetDirectoryName(piperExe)
+        });
+
+        modelTask = LoadOrDownloadModelAsync(config);
+        soundQueue = new StreamingSoundQueue(config);
+    }
+    public static bool IsModelFileDownloaded(PluginConfiguration config)
+    {
+        var piperExePath = Path.Combine(config.GetPluginConfigDirectory(), "piper", "piper.exe");
+        return File.Exists(piperExePath);
+    }
+
+    /// Downloads the Piper executable and initial voice models.
+    public async Task EnsurePiperAssetsDownloaded(PluginConfiguration config)
+    {
+        string configDir = config.GetPluginConfigDirectory();
+        string voicesDir = GetVoicesDir(config);
+        var allModels = await PiperDownloader.GetHuggingFaceModelList();
+
+        var filteredModels = allModels
+            .Where(m => m.Key.StartsWith("en") && m.Key.EndsWith("medium"))
+            .ToList();
+
+        foreach (var modelEntry in filteredModels)
+        {
+            string modelKey = modelEntry.Key;
+            string modelTargetDir = Path.Combine(voicesDir, modelKey);
+
+            if (File.Exists(Path.Combine(modelTargetDir, $"{modelKey}.onnx"))) continue;
+
+            try
+            {
+                DetailedLog.Info($"Downloading English medium voice: {modelKey}");
+                await modelEntry.Value.DownloadModel(voicesDir);
+
+                string onnxPath = Path.Combine(modelTargetDir, $"{modelKey}.onnx");
+                await LoadSpecificVoiceModel(onnxPath);
+            }
+            catch (Exception ex)
+            {
+                DetailedLog.Error($"Failed to download {modelKey}: {ex.Message}");
+            }
+        }
+    }
+
+    private async Task<VoiceModel> LoadOrDownloadModelAsync(PluginConfiguration config)
+    {
+
+        string modelKey = "en_US-lessac-medium";
+        string modelDir = Path.Combine(GetVoicesDir(config), modelKey);
+        string onnxFilePath = Path.Combine(modelDir, $"{modelKey}.onnx");
+
+        if (!File.Exists(onnxFilePath))
+        {
+            await EnsurePiperAssetsDownloaded(config);
+        }
+
+        return await LoadSpecificVoiceModel(onnxFilePath);
+    }
+
+    private async Task<VoiceModel> LoadSpecificVoiceModel(string onnxFilePath)
+    {
+        string modelDir = Path.GetDirectoryName(onnxFilePath);
+        string configFilePath = onnxFilePath + ".json";
+        string piperSharpExpectedJson = Path.Combine(modelDir, "model.json");
+
+        if (File.Exists(configFilePath) && !File.Exists(piperSharpExpectedJson))
+        {
+            File.Copy(configFilePath, piperSharpExpectedJson, true);
+        }
+
+        return await VoiceModel.LoadModel(modelDir);
+    }
+
+    private bool TryGetModel([NotNullWhen(true)] out VoiceModel? tts)
+    {
+        if (modelTask.IsCompletedSuccessfully)
+        {
+            tts = modelTask.Result;
+            return true;
+        }
+
+        tts = null;
+        return false;
+    }
+
+    public override void Say(SayRequest request)
+    {
+        if (request.Voice is not PiperVoicePreset voicePreset)
+            throw new InvalidOperationException("Invalid voice preset.");
+
+        if (!modelTask.IsCompletedSuccessfully) return;
+
+        Say(request.Text, voicePreset, request.Source);
+    }
+
+    public async Task Say(string text, PiperVoicePreset voicePreset, TextSource source)
+    {
+        long methodStart = Stopwatch.GetTimestamp();
+        long? timestampToPass = methodStart;
+
+        if (string.IsNullOrEmpty(voicePreset.ModelPath) || !File.Exists(voicePreset.ModelPath))
+        {
+            DetailedLog.Error($"Piper model file not found: {voicePreset.ModelPath}");
+            return;
+        }
+
+        try
+        {
+            var voiceDir = Path.GetDirectoryName(voicePreset.ModelPath);
+            var voiceModel = await VoiceModel.LoadModel(voiceDir);
+
+            piper.Configuration.Model = voiceModel;
+            piper.Configuration.SpeakingRate = 1.0f / voicePreset.Speed ?? 1f;
+
+            byte[] audioData = await piper.InferAsync(text, AudioOutputType.Raw, cts.Token);
+            if (audioData == null || audioData.Length == 0) return;
+            var audioStream = new MemoryStream(audioData);
+            soundQueue.EnqueueSound(audioStream, source, voicePreset.Volume ?? 1f, StreamFormat.Piper, null, timestampToPass);
+        }
+        catch (Exception ex)
+        {
+            DetailedLog.Error($"Piper switching/inference failed: {ex.Message}");
+        }
+    }
+
+    public override void CancelAllSpeech()
+    {
+        soundQueue.CancelAllSounds();
+    }
+
+    public override void CancelSay(TextSource source)
+    {
+        soundQueue.CancelFromSource(source);
+    }
+
+    public override void DrawSettings(IConfigUIDelegates helpers)
+    {
+        if (TryGetModel(out _))
+        {
+            ui.DrawVoicePresetOptions();
+            return;
+        }
+
+        if (modelTask.Status == TaskStatus.Faulted)
+        {
+            ImGui.TextColored(ImColor.Red, $"Failed to download model: {modelTask.Exception?.Message}");
+            DetailedLog.Error($"Failed to download Piper model: {modelTask.Exception}");
+        }
+        else
+        {
+            ImGui.TextColored(ImColor.HintColor, "Model is still downloading or initializing...");
+        }
+    }
+
+    public override TextSource GetCurrentlySpokenTextSource()
+    {
+        return soundQueue.GetCurrentlySpokenTextSource();
+    }
+    public override void DrawStyles(IConfigUIDelegates helpers)
+    {
+        helpers.OpenVoiceStylesConfig();
+    }
+    protected override void Dispose(bool disposing)
+    {
+        cts.Cancel();
+
+        if (disposing)
+        {
+            soundQueue?.Dispose();
+            cts.Dispose();
+        }
+    }
+
+}

--- a/src/TextToTalk/Backends/Piper/PiperBackend.cs
+++ b/src/TextToTalk/Backends/Piper/PiperBackend.cs
@@ -44,7 +44,6 @@ public class PiperBackend : VoiceBackend
         this.piper = new PiperProvider(new PiperConfiguration()
         {
             ExecutableLocation = piperExe,
-            // 2. Set the working directory to the folder containing the .exe
             WorkingDirectory = piperBaseDir
         });
 
@@ -74,10 +73,8 @@ public class PiperBackend : VoiceBackend
         try
         {
             DetailedLog.Info($"Downloading voice: {modelKey}");
-            // Downloads into voicesDir/modelKey/
             await entry.DownloadModel(voicesDir);
 
-            // Prepare the model.json for PiperSharp
             string onnxPath = Path.Combine(modelTargetDir, $"{modelKey}.onnx");
             await LoadSpecificVoiceModel(onnxPath);
 
@@ -101,7 +98,6 @@ public class PiperBackend : VoiceBackend
 
             if (Directory.Exists(modelTargetDir))
             {
-                // Delete the folder and all contents (.onnx, .json)
                 Directory.Delete(modelTargetDir, true);
                 DetailedLog.Info($"Deleted voice model: {modelKey}");
                 return true;
@@ -120,10 +116,8 @@ public class PiperBackend : VoiceBackend
         string configDir = config.GetPluginConfigDirectory();
         string voicesDir = GetVoicesDir(config);
 
-        // Ensure the executable is downloaded first
         await EnsureExecutableDownloaded(config);
 
-        // Fetch all available models from Hugging Face
         var allModels = await PiperDownloader.GetHuggingFaceModelList();
 
         // TARGET: Only download "en_US-lessac-medium" initially
@@ -140,12 +134,10 @@ public class PiperBackend : VoiceBackend
                 {
                     DetailedLog.Info($"Downloading starter English voice: {starterModelKey}");
 
-                    // Downloads the model to voicesDir/en_US-lessac-medium/
                     await modelEntry.DownloadModel(voicesDir);
 
                     string onnxPath = Path.Combine(modelTargetDir, $"{starterModelKey}.onnx");
 
-                    // Initialize the model config and directory
                     await LoadSpecificVoiceModel(onnxPath);
                 }
                 catch (Exception ex)

--- a/src/TextToTalk/Backends/Piper/PiperBackendUI.cs
+++ b/src/TextToTalk/Backends/Piper/PiperBackendUI.cs
@@ -1,0 +1,132 @@
+﻿using Dalamud.Bindings.ImGui;
+using Dalamud.Utility;
+using System;
+using System.IO;
+using System.Linq;
+using TextToTalk.UI;
+
+namespace TextToTalk.Backends.Piper;
+
+public class PiperBackendUI(PluginConfiguration config, PiperBackend piperBackend)
+{
+    private string[] availableModelPaths;
+    private string[] modelDisplayNames;
+    private int selectedModelIndex = -1;
+
+    public void DrawVoicePresetOptions()
+    {
+        ImGui.TextColored(ImColor.HintColor, "Piper is a local neural TTS engine. Ensure you have downloaded models.");
+
+        ImGui.Spacing();
+
+        var currentVoicePreset = config.GetCurrentVoicePreset<PiperVoicePreset>();
+        var presets = config.GetVoicePresetsForBackend(TTSBackend.Piper).ToList();
+
+        if (presets.Count > 0 && currentVoicePreset != null)
+        {
+            var presetIndex = currentVoicePreset is not null ? presets.IndexOf(currentVoicePreset) : -1;
+            if (ImGui.Combo($"Voice preset##{MemoizedId.Create()}", ref presetIndex,
+                    presets.Select(p => p.Name).ToArray(), presets.Count))
+            {
+                config.SetCurrentVoicePreset(presets[presetIndex].Id);
+                config.Save();
+                selectedModelIndex = -1;
+            }
+        }
+        else if (currentVoicePreset != null)
+        {
+            ImGui.TextColored(ImColor.Red, "You have no presets. Create one to begin.");
+        }
+        else if (currentVoicePreset == null && presets.Count > 0)
+        {
+            config.SetCurrentVoicePreset(presets.First().Id);
+        }
+
+        BackendUI.NewPresetButton<PiperVoicePreset>($"New preset##{MemoizedId.Create()}", config);
+
+        if (presets.Count == 0 || currentVoicePreset is null) return;
+
+        ImGui.SameLine();
+        BackendUI.DeletePresetButton($"Delete preset##{MemoizedId.Create()}", currentVoicePreset, TTSBackend.Piper, config);
+
+        ImGui.Separator();
+
+        var presetName = currentVoicePreset.Name;
+        if (ImGui.InputText($"Preset name##{MemoizedId.Create()}", ref presetName, 64))
+        {
+            currentVoicePreset.Name = presetName;
+            config.Save();
+        }
+
+        // --- Model Selection ---
+        var piperDir = Path.Combine(config.GetPluginConfigDirectory(), "piper");
+        var voicesDir = Path.Combine(piperDir, "voices");
+
+        if (!Directory.Exists(voicesDir))
+            Directory.CreateDirectory(voicesDir);
+
+        availableModelPaths = Directory.GetFiles(voicesDir, "*.onnx", SearchOption.AllDirectories);
+        modelDisplayNames = availableModelPaths.Select(Path.GetFileName).ToArray();
+
+        if (availableModelPaths.Length > 0)
+        {
+            if (selectedModelIndex == -1 ||
+                selectedModelIndex >= availableModelPaths.Length ||
+                availableModelPaths[selectedModelIndex] != currentVoicePreset.ModelPath)
+            {
+                selectedModelIndex = Array.IndexOf(availableModelPaths, currentVoicePreset.ModelPath ?? "");
+                if (selectedModelIndex == -1) selectedModelIndex = 0;
+            }
+
+            if (ImGui.Combo($"Voice Model (.onnx)##{MemoizedId.Create()}", ref selectedModelIndex, modelDisplayNames, modelDisplayNames.Length))
+            {
+                currentVoicePreset.ModelPath = availableModelPaths[selectedModelIndex];
+                currentVoicePreset.InternalName = modelDisplayNames[selectedModelIndex].Replace(".onnx", "");
+                config.Save();
+            }
+        }
+        else
+        {
+            ImGui.TextColored(ImColor.Red, $"No .onnx models found in subdirectories of: {voicesDir}");
+        }
+
+        if (ImGui.Button($"Download Models##{MemoizedId.Create()}"))
+        {
+            _ = piperBackend.EnsurePiperAssetsDownloaded(config);
+        }
+        Components.Tooltip("Will download all English voices at medium quality (appx 1.5GB)");
+
+        // --- Voice Parameters ---
+        var speed = currentVoicePreset.Speed ?? 1f;
+        if (ImGui.SliderFloat($"Speed##{MemoizedId.Create()}", ref speed, 0.5f, 3.0f, "%.2fx"))
+        {
+            currentVoicePreset.Speed = speed;
+            config.Save();
+        }
+
+        var volume = (int)((currentVoicePreset.Volume ?? 1.0f) * 100);
+        if (ImGui.SliderInt($"Volume##{MemoizedId.Create()}", ref volume, 0, 200, "%d%%"))
+        {
+            currentVoicePreset.Volume = MathF.Round((float)volume / 100, 2);
+            config.Save();
+        }
+
+        if (ImGui.Button($"Test##{MemoizedId.Create()}"))
+        {
+            if (!string.IsNullOrEmpty(currentVoicePreset.ModelPath) && File.Exists(currentVoicePreset.ModelPath))
+            {
+                piperBackend.CancelSay(TextSource.Chat);
+                piperBackend.Say($"Hello from Piper neural engine. This is a test message", currentVoicePreset,
+                    TextSource.Chat);
+            }
+        }
+
+        ImGui.Separator();
+
+        ConfigComponents.ToggleUseGenderedVoicePresets($"Use gendered voices##{MemoizedId.Create()}", config);
+        if (config.UseGenderedVoicePresets)
+        {
+            BackendUI.GenderedPresetConfig("Piper", TTSBackend.Piper, config, presets);
+        }
+    }
+}

--- a/src/TextToTalk/Backends/Piper/PiperBackendUI.cs
+++ b/src/TextToTalk/Backends/Piper/PiperBackendUI.cs
@@ -5,7 +5,10 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
+using System.Threading.Tasks;
 using TextToTalk.UI;
+using PiperSharp;
+using PiperSharp.Models;
 
 namespace TextToTalk.Backends.Piper;
 
@@ -15,11 +18,20 @@ public class PiperBackendUI(PluginConfiguration config, PiperBackend piperBacken
     private string[] modelDisplayNames;
     private int selectedModelIndex = -1;
 
+    private bool showDownloader = false;
+    private IDictionary<string, VoiceModel> remoteModels;
+    private string searchQuery = "";
+    private List<PiperModelInfo> cachedModels = new(); // For live list updates
+    private DateTime lastScan = DateTime.MinValue;
+    private bool isScanning = false;
+
     public class PiperModelInfo
     {
         public string FullPath { get; set; }
         public string DisplayName { get; set; }
         public string Quality { get; set; } // low, medium, high
+
+        
 
         public static PiperModelInfo FromPath(string onnxPath)
         {
@@ -49,7 +61,8 @@ public class PiperBackendUI(PluginConfiguration config, PiperBackend piperBacken
 
     private List<PiperModelInfo> sortedModels = new();
     private string[] sortedDisplayNames = Array.Empty<string>();
-    
+    private string voicesFolderSize = "0 MB";
+
     public void DrawVoicePresetOptions()
     {
         ImGui.TextColored(ImColor.HintColor, "Piper is a local neural TTS engine. Ensure you have downloaded models.");
@@ -95,16 +108,45 @@ public class PiperBackendUI(PluginConfiguration config, PiperBackend piperBacken
             config.Save();
         }
 
+        // 1. REFACTORED MODEL SCANNING (Async polling for new downloads)
+        if (!isScanning && (DateTime.Now - lastScan).TotalSeconds > 3)
+        {
+            lastScan = DateTime.Now;
+            isScanning = true;
+
+            Task.Run(() =>
+            {
+                try
+                {
+                    var voicesDir = Path.Combine(config.GetPluginConfigDirectory(), "piper", "voices");
+                    if (Directory.Exists(voicesDir))
+                    {
+                        // 1. Existing Model Scanning logic
+                        var files = Directory.GetFiles(voicesDir, "*.onnx", SearchOption.AllDirectories);
+                        cachedModels = files.Select(PiperModelInfo.FromPath).Where(m => m != null).ToList();
+
+                        // 2. NEW: Calculate Folder Size
+                        var dirInfo = new DirectoryInfo(voicesDir);
+                        // Sum all files in all subdirectories
+                        long totalBytes = dirInfo.EnumerateFiles("*", SearchOption.AllDirectories).Sum(fi => fi.Length);
+
+                        // Convert to MB and format
+                        voicesFolderSize = $"{(totalBytes / 1024f / 1024f):N0} MB";
+                    }
+                }
+                finally { isScanning = false; }
+            });
+        }
+
         // Model Selection
         var voicesDir = Path.Combine(config.GetPluginConfigDirectory(), "piper", "voices");
         if (!Directory.Exists(voicesDir)) Directory.CreateDirectory(voicesDir);
 
         var files = Directory.GetFiles(voicesDir, "*.onnx", SearchOption.AllDirectories);
         var allModels = files.Select(PiperModelInfo.FromPath).Where(m => m != null).ToList();
-
-        if (allModels.Count > 0)
+        if (cachedModels.Count > 0)
         {
-            ImGui.Text("Voice Model Selection");
+
 
             var currentModel = allModels.FirstOrDefault(m => m.FullPath == currentVoicePreset.ModelPath);
             string previewValue = currentModel?.DisplayName ?? "Select a model...";
@@ -148,17 +190,13 @@ public class PiperBackendUI(PluginConfiguration config, PiperBackend piperBacken
                 }
                 ImGui.EndCombo();
             }
+            ImGui.SameLine();
+            ImGui.Text("Voice Model Selection");
         }
         else
         {
             ImGui.TextColored(ImColor.Red, "No voice models found.");
         }
-
-        if (ImGui.Button($"Download Models##{MemoizedId.Create()}"))
-        {
-            _ = piperBackend.EnsurePiperAssetsDownloaded(config);
-        }
-        Components.Tooltip("Will download all English voices at medium quality (appx 1.5GB)");
 
         // --- Voice Parameters ---
         var speed = currentVoicePreset.Speed ?? 1f;
@@ -184,6 +222,35 @@ public class PiperBackendUI(PluginConfiguration config, PiperBackend piperBacken
                     TextSource.Chat);
             }
         }
+        ImGui.SameLine();
+        if (ImGui.Button($"Open Voice Downloader##{MemoizedId.Create()}"))
+        {
+            showDownloader = true;
+            // 2026 Best Practice: Fetch manifest on a background thread to prevent FFXIV frame drops
+            Task.Run(async () =>
+            {
+                try
+                {
+                    // Ensure this returns IDictionary<string, PiperModel> or similar
+                    var models = await piperBackend.GetAvailableModels();
+                    // Cast or assign to your IDictionary<string, VoiceModel> field
+                    remoteModels = models.ToDictionary(k => k.Key, v => (VoiceModel)v.Value);
+                }
+                catch (Exception ex)
+                {
+                    DetailedLog.Error($"Failed to fetch Piper manifest: {ex.Message}");
+                }
+            });
+        }
+        Components.Tooltip("Browse and download specific Piper voices from Hugging Face.");
+        ImGui.SameLine();
+        ImGui.TextDisabled($"Local Storage Used: {voicesFolderSize}");
+        if (ImGui.IsItemHovered())
+        {
+            ImGui.SetTooltip("Total disk space used by downloaded Piper voice models.");
+        }
+        // Render the window if active
+        if (showDownloader) DrawVoiceDownloader();
 
         ImGui.Separator();
 
@@ -192,5 +259,100 @@ public class PiperBackendUI(PluginConfiguration config, PiperBackend piperBacken
         {
             BackendUI.GenderedPresetConfig("Piper", TTSBackend.Piper, config, presets);
         }
+    }
+    private void DrawVoiceDownloader()
+    {
+        ImGui.SetNextWindowSize(new global::System.Numerics.Vector2(500, 600), ImGuiCond.FirstUseEver);
+        if (ImGui.Begin("Piper Voice Downloader", ref showDownloader))
+        {
+            if (remoteModels == null)
+            {
+                ImGui.Text("Fetching model list from Hugging Face...");
+                ImGui.End();
+                return;
+            }
+
+            ImGui.InputTextWithHint("##Search", "Search voices (e.g. 'en_US' or 'medium')...", ref searchQuery, 64);
+
+            ImGui.BeginChild("ModelList", new global::System.Numerics.Vector2(0, 0), true);
+            foreach (var model in remoteModels)
+            {
+
+                var entry = model.Value;
+                var langName = entry.Language?.Name ?? "Unknown";
+                var dataset = entry.Name ?? "Standard";
+                var parts = (entry.Key ?? "unknown").Split(new[] { '-', '_' }, StringSplitOptions.RemoveEmptyEntries);
+                string quality = parts.Last().ToLower();
+
+                string formattedName = $"{langName} : {dataset} ({quality})";
+
+                if (!string.IsNullOrEmpty(searchQuery) && !model.Key.Contains(searchQuery, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                // Check if installed
+                bool isDownloaded = cachedModels.Any(m => m.FullPath.Contains(model.Key));
+                bool isInstalled = cachedModels.Any(m => m.FullPath.Contains(Path.Combine("voices", model.Key)));
+
+                ImGui.PushID(model.Key);
+                ImGui.TextUnformatted(formattedName);
+                ImGui.SameLine(ImGui.GetWindowWidth() - 120);
+
+                if (isInstalled)
+                {
+                    ImGui.TextColored(new global::System.Numerics.Vector4(0.5f, 1f, 0.5f, 1f), "Installed");
+
+                    // Add a small delete button to the right of the "Installed" text
+                    ImGui.SameLine(ImGui.GetWindowWidth() - 40);
+                    ImGui.PushStyleColor(ImGuiCol.Button, new global::System.Numerics.Vector4(0.6f, 0.2f, 0.2f, 1f)); // Reddish
+                    if (ImGui.Button("X##Delete"))
+                    {
+                        // Trigger deletion
+                        if (piperBackend.DeleteVoiceModel(model.Key))
+                        {
+                            // Force a re-scan of the local files immediately so the UI updates
+                            lastScan = DateTime.MinValue;
+                        }
+                    }
+                    ImGui.PopStyleColor();
+                    if (ImGui.IsItemHovered()) ImGui.SetTooltip("Delete this voice model from your computer.");
+                }
+                else
+                {
+                    if (ImGui.Button("Download"))
+                    {
+                        _ = piperBackend.DownloadSpecificModel(model.Key, (VoiceModel)model.Value);
+                    }
+                }
+                ImGui.Separator();
+                ImGui.PopID();
+            }
+            ImGui.EndChild();
+            ImGui.End();
+        }
+
+    }
+    public bool DeleteVoiceModel(string modelKey)
+    {
+        try
+        {
+            // 1. Kill any active speech to unlock files
+            piperBackend.KillActiveProcessInternal();
+
+            string voicesDir = piperBackend.GetVoicesDir(config);
+            string modelTargetDir = Path.Combine(voicesDir, modelKey);
+
+            if (Directory.Exists(modelTargetDir))
+            {
+                // Delete the folder and all contents (.onnx, .json)
+                Directory.Delete(modelTargetDir, true);
+                DetailedLog.Info($"Deleted voice model: {modelKey}");
+                return true;
+            }
+        }
+        catch (Exception ex)
+        {
+            DetailedLog.Error($"Failed to delete {modelKey}: {ex.Message}");
+        }
+        return false;
     }
 }

--- a/src/TextToTalk/Backends/Piper/PiperSoundQueueItem.cs
+++ b/src/TextToTalk/Backends/Piper/PiperSoundQueueItem.cs
@@ -1,0 +1,29 @@
+﻿using Dalamud.Game;
+using TextToTalk.Backends.Piper;
+
+namespace TextToTalk.Backends.Piper;
+
+public class PiperSoundQueueItem : SoundQueueItem
+{
+    public string Text { get; }
+    public PiperVoicePreset Voice { get; }
+
+    public float Speed { get; }
+    public float Volume { get; }
+    public bool Aborted { get; private set; }
+    public ClientLanguage Language { get; }
+
+    public long? StartTime { get; set; }
+
+    public PiperSoundQueueItem(string text, PiperVoicePreset voice, TextSource source, ClientLanguage language, long? startTime)
+    {
+        Text = text;
+        Voice = voice;
+        Source = source;
+        Language = language;
+        StartTime = startTime;
+
+        Speed = voice.Speed ?? 1.0f;
+        Volume = voice.Volume ?? 1.0f;
+    }
+}

--- a/src/TextToTalk/Backends/Piper/PiperVoicePreset.cs
+++ b/src/TextToTalk/Backends/Piper/PiperVoicePreset.cs
@@ -1,0 +1,26 @@
+﻿using Newtonsoft.Json;
+
+namespace TextToTalk.Backends.Piper;
+
+public class PiperVoicePreset : VoicePreset
+{
+    [JsonProperty("ModelName")]
+    public string? InternalName { get; set; }
+
+    [JsonProperty("ModelPath")]
+    public string? ModelPath { get; set; }
+
+    public float? Speed { get; set; }
+
+    public float? Volume { get; set; }
+
+    public override bool TrySetDefaultValues()
+    {
+        InternalName = "en_US-lessac-medium";
+        ModelPath = ""; // To be populated by the file picker or downloader
+        Speed = 1.0f;
+        Volume = 1.0f;
+        EnabledBackend = TTSBackend.Piper;
+        return true;
+    }
+}

--- a/src/TextToTalk/Backends/Polly/PollyBackend.cs
+++ b/src/TextToTalk/Backends/Polly/PollyBackend.cs
@@ -9,17 +9,18 @@ namespace TextToTalk.Backends.Polly
     {
         private readonly PollyBackendUI ui;
         private readonly PollyBackendUIModel uiModel;
+        private readonly LatencyTracker latencyTracker;
 
-        public PollyBackend(PluginConfiguration config, HttpClient http)
+        public PollyBackend(PluginConfiguration config, HttpClient http, LatencyTracker latencyTracker)
         {
             TitleBarColor = ImGui.ColorConvertU32ToFloat4(0xFF0099FF);
 
             var lexiconManager = new DalamudLexiconManager();
-            this.uiModel = new PollyBackendUIModel(config, lexiconManager);
+            this.uiModel = new PollyBackendUIModel(config, lexiconManager, latencyTracker);
 
             LexiconUtils.LoadFromConfigPolly(lexiconManager, config);
 
-            this.ui = new PollyBackendUI(this.uiModel, config, lexiconManager, http, this);
+            this.ui = new PollyBackendUI(this.uiModel, config, lexiconManager, http, this, latencyTracker);
         }
 
         public override void DrawStyles(IConfigUIDelegates helpers)

--- a/src/TextToTalk/Backends/Polly/PollyBackendUI.cs
+++ b/src/TextToTalk/Backends/Polly/PollyBackendUI.cs
@@ -2,6 +2,7 @@
 using Dalamud.Bindings.ImGui;
 using Dalamud.Game;
 using Dalamud.Game.Text;
+using FFXIVClientStructs;
 using System;
 using System.IO;
 using System.Linq;
@@ -19,12 +20,13 @@ public class PollyBackendUI
     private readonly LexiconComponent lexiconComponent;
     private readonly PollyBackendUIModel model;
     private readonly PollyBackend backend;
+    private readonly LatencyTracker latencyTracker;
 
     private string accessKey;
     private string secretKey;
 
     public PollyBackendUI(PollyBackendUIModel model, PluginConfiguration config, LexiconManager lexiconManager,
-        HttpClient http, PollyBackend backend)
+        HttpClient http, PollyBackend backend, LatencyTracker latencyTracker)
     {
         this.model = model;
 
@@ -39,7 +41,9 @@ public class PollyBackendUI
             new LexiconComponent(lexiconManager, lexiconRepository, config, () => config.PollyLexiconFiles);
 
         (this.accessKey, this.secretKey) = this.model.GetKeyPair();
+        this.latencyTracker = latencyTracker;
     }
+    
 
     public void DrawSettings(IConfigUIDelegates helpers)
     {
@@ -58,7 +62,7 @@ public class PollyBackendUI
 
         if (ImGui.Button($"Save and Login##{MemoizedId.Create()}"))
         {
-            this.model.LoginWith(this.accessKey, this.secretKey);
+            this.model.LoginWith(this.accessKey, this.secretKey, this.latencyTracker);
         }
 
         ImGui.SameLine();

--- a/src/TextToTalk/Backends/Polly/PollyClient.cs
+++ b/src/TextToTalk/Backends/Polly/PollyClient.cs
@@ -85,20 +85,15 @@ namespace TextToTalk.Backends.Polly
             bool isFirstChunk = true;
             try
             {
-                // Using 'using' ensures the response (and its stream) is disposed after the queue handles it
                 var res = await this.client.SynthesizeSpeechAsync(req, ct);
 
-                // Pass the live AudioStream directly to the queue.
-                // Ensure EnqueueSound is updated to process the stream as it arrives.
                 long? timestampToPass = isFirstChunk ? methodStart : null;
                 this.soundQueue.EnqueueSound(res.AudioStream, source, volume, StreamFormat.Mp3, null, timestampToPass);
                 isFirstChunk = false;
             }
             catch (OperationCanceledException)
             {
-                // 2026 Best Practice: Catch the cancellation exception to prevent it 
-                // from bubbling up as a generic error.
-                Log.Information("TTS generation was cancelled.");
+                // Silently ignore cancellations
             }
             catch (Exception e)
             {

--- a/src/TextToTalk/Backends/Polly/PollyClient.cs
+++ b/src/TextToTalk/Backends/Polly/PollyClient.cs
@@ -2,9 +2,11 @@
 using Amazon.Polly;
 using Amazon.Polly.Model;
 using Amazon.Runtime;
+using Serilog;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using TextToTalk.Lexicons;
 
@@ -13,15 +15,17 @@ namespace TextToTalk.Backends.Polly
     public class PollyClient : IDisposable
     {
         private readonly AmazonPollyClient client;
-        private readonly StreamSoundQueue soundQueue;
+        private readonly StreamingSoundQueue soundQueue;
         private readonly LexiconManager lexiconManager;
         private readonly PluginConfiguration config;
+
+        public CancellationTokenSource? _TtsCts;
 
         public PollyClient(string accessKey, string secretKey, RegionEndpoint region, LexiconManager lexiconManager, PluginConfiguration config)
         {
             var credentials = new BasicAWSCredentials(accessKey, secretKey);
             this.client = new AmazonPollyClient(credentials, region);
-            this.soundQueue = new StreamSoundQueue(config);
+            this.soundQueue = new StreamingSoundQueue(config);
             this.lexiconManager = lexiconManager;
         }
 
@@ -53,6 +57,12 @@ namespace TextToTalk.Backends.Polly
         public async Task Say(Engine engine, VoiceId voice, string? amazonDomainName, int sampleRate, int playbackRate,
             float volume, TextSource source, string text)
         {
+            _TtsCts?.Cancel();
+            _TtsCts?.Dispose();
+
+            _TtsCts = new CancellationTokenSource();
+            var ct = _TtsCts.Token;
+
             if (!string.IsNullOrEmpty(amazonDomainName))
             {
                 text = $"<amazon:domain name=\"{amazonDomainName}\">{text}</amazon:domain>";
@@ -71,33 +81,48 @@ namespace TextToTalk.Backends.Polly
                 TextType = TextType.Ssml,
             };
 
-            SynthesizeSpeechResponse res;
             try
             {
-                res = await this.client.SynthesizeSpeechAsync(req);
+                // Using 'using' ensures the response (and its stream) is disposed after the queue handles it
+                var res = await this.client.SynthesizeSpeechAsync(req, ct);
+
+                // Pass the live AudioStream directly to the queue.
+                // Ensure EnqueueSound is updated to process the stream as it arrives.
+                this.soundQueue.EnqueueSound(res.AudioStream, source, volume, StreamFormat.Mp3, null);
+            }
+            catch (OperationCanceledException)
+            {
+                // 2026 Best Practice: Catch the cancellation exception to prevent it 
+                // from bubbling up as a generic error.
+                Log.Information("TTS generation was cancelled.");
             }
             catch (Exception e)
             {
                 DetailedLog.Error(e, "Synthesis request failed in {0}.", nameof(PollyClient));
-                return;
             }
 
-            var responseStream = new MemoryStream();
-            await res.AudioStream.CopyToAsync(responseStream);
-            responseStream.Seek(0, SeekOrigin.Begin);
-
-            this.soundQueue.EnqueueSound(responseStream, source, StreamFormat.Mp3, volume);
         }
 
         public Task CancelAllSounds()
         {
             this.soundQueue.CancelAllSounds();
+            if (this._TtsCts != null)
+            {
+                this._TtsCts.Cancel();
+            }
+            this.soundQueue.StopHardware();
             return Task.CompletedTask;
         }
 
         public Task CancelFromSource(TextSource source)
         {
             this.soundQueue.CancelFromSource(source);
+            this.soundQueue.CancelAllSounds();
+            if (this._TtsCts != null)
+            {
+                this._TtsCts.Cancel();
+            }
+            this.soundQueue.StopHardware();
             return Task.CompletedTask;
         }
 

--- a/src/TextToTalk/Backends/Polly/PollyClient.cs
+++ b/src/TextToTalk/Backends/Polly/PollyClient.cs
@@ -22,11 +22,11 @@ namespace TextToTalk.Backends.Polly
 
         public CancellationTokenSource? _TtsCts;
 
-        public PollyClient(string accessKey, string secretKey, RegionEndpoint region, LexiconManager lexiconManager, PluginConfiguration config)
+        public PollyClient(string accessKey, string secretKey, RegionEndpoint region, LexiconManager lexiconManager, PluginConfiguration config, LatencyTracker latencyTracker)
         {
             var credentials = new BasicAWSCredentials(accessKey, secretKey);
             this.client = new AmazonPollyClient(credentials, region);
-            this.soundQueue = new StreamingSoundQueue(config);
+            this.soundQueue = new StreamingSoundQueue(config, latencyTracker);
             this.lexiconManager = lexiconManager;
         }
 

--- a/src/TextToTalk/Backends/SoundQueue.cs
+++ b/src/TextToTalk/Backends/SoundQueue.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Serilog;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;

--- a/src/TextToTalk/Backends/StreamFormat.cs
+++ b/src/TextToTalk/Backends/StreamFormat.cs
@@ -5,4 +5,7 @@ public enum StreamFormat
     Mp3,
     Wave,
     Raw,
+    Azure,
+    System,
+    Uberduck,
 }

--- a/src/TextToTalk/Backends/StreamFormat.cs
+++ b/src/TextToTalk/Backends/StreamFormat.cs
@@ -9,4 +9,6 @@ public enum StreamFormat
     System,
     Uberduck,
     Piper,
+    PiperLow,
+    PiperHigh,
 }

--- a/src/TextToTalk/Backends/StreamFormat.cs
+++ b/src/TextToTalk/Backends/StreamFormat.cs
@@ -8,4 +8,5 @@ public enum StreamFormat
     Azure,
     System,
     Uberduck,
+    Piper,
 }

--- a/src/TextToTalk/Backends/StreamFormat.cs
+++ b/src/TextToTalk/Backends/StreamFormat.cs
@@ -4,11 +4,9 @@ public enum StreamFormat
 {
     Mp3,
     Wave,
+    Wave8K,
+    Wave16K,
+    Wave22K,
     Raw,
-    Azure,
     System,
-    Uberduck,
-    Piper,
-    PiperLow,
-    PiperHigh,
 }

--- a/src/TextToTalk/Backends/StreamSoundQueue.cs
+++ b/src/TextToTalk/Backends/StreamSoundQueue.cs
@@ -1,5 +1,6 @@
 ﻿using NAudio.Wave;
 using NAudio.Wave.SampleProviders;
+using Serilog;
 using System;
 using System.IO;
 using System.Threading;
@@ -32,6 +33,7 @@ namespace TextToTalk.Backends
             // Play the sound
             lock (this.soundLock)
             {
+                Log.Information("Playing");
                 this.soundOut = new DirectSoundOut(playbackDeviceId);
                 this.soundOut.PlaybackStopped += (_, _) => { this.speechCompleted.Set(); };
                 this.soundOut.Init(volumeSampleProvider);

--- a/src/TextToTalk/Backends/StreamSoundQueueItem.cs
+++ b/src/TextToTalk/Backends/StreamSoundQueueItem.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using System.Net.Http;
+using System.Diagnostics;
 using static TextToTalk.Backends.System.SystemSoundQueue;
 
 namespace TextToTalk.Backends
@@ -36,6 +37,8 @@ namespace TextToTalk.Backends
             public StreamFormat Format { get; init; }
             public HttpResponseMessage? Response { get; set; }
             public bool Aborted { get; set; }
+
+            public long? StartTime { get; set; } // Use GetTimestamp() value
 
             protected override void Dispose(bool disposing)
             {

--- a/src/TextToTalk/Backends/StreamSoundQueueItem.cs
+++ b/src/TextToTalk/Backends/StreamSoundQueueItem.cs
@@ -1,4 +1,6 @@
 ﻿using System.IO;
+using System.Net.Http;
+using static TextToTalk.Backends.System.SystemSoundQueue;
 
 namespace TextToTalk.Backends
 {
@@ -10,14 +12,44 @@ namespace TextToTalk.Backends
 
         public StreamFormat Format { get; init; }
 
+
         protected override void Dispose(bool disposing)
         {
             if (disposing)
             {
-                Data.Dispose();
-            }
+                try
+                {
+                    Data.Dispose();
+                }
+                catch { }
 
-            base.Dispose(disposing);
+                base.Dispose(disposing);
+            }
+        }
+
+        public class StreamingSoundQueueItem : SoundQueueItem
+        {
+            public Stream Data { get; init; }
+
+            public float Volume { get; init; }
+
+            public StreamFormat Format { get; init; }
+            public HttpResponseMessage? Response { get; set; }
+            public bool Aborted { get; set; }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    try
+                    {
+                        Data.Dispose();
+                    }
+                    catch { }
+
+                    base.Dispose(disposing);
+                }                                           
+            }
         }
     }
 }

--- a/src/TextToTalk/Backends/StreamingSoundQueue.cs
+++ b/src/TextToTalk/Backends/StreamingSoundQueue.cs
@@ -114,19 +114,22 @@ namespace TextToTalk.Backends
                     {
                         lock (this.soundLock)
                         {
-                            
-                            this.bufferedProvider.AddSamples(decompressedBuffer, 0, decompressedBytes);
-
-                            if (this.bufferedProvider.BufferedBytes > 4096 &&
-                                this.soundOut.PlaybackState != PlaybackState.Playing)
+                            if (this.bufferedProvider != null && this.soundOut != null)
                             {
-                                if (nextItem.StartTime.HasValue)
+                                this.bufferedProvider.AddSamples(decompressedBuffer, 0, decompressedBytes);
+                                if (this.bufferedProvider.BufferedBytes > 4096 &&
+                                    this.soundOut.PlaybackState != PlaybackState.Playing)
                                 {
-                                    var elapsed = Stopwatch.GetElapsedTime(nextItem.StartTime.Value);
-                                    Log.Information("Total Latency (Say -> Play): {Ms}ms", elapsed.TotalMilliseconds);
+                                    if (nextItem.StartTime.HasValue)
+                                    {
+                                        var elapsed = Stopwatch.GetElapsedTime(nextItem.StartTime.Value);
+                                        Log.Information("Total Latency (Say -> PlayMp3): {Ms}", elapsed.TotalMilliseconds);
+                                    }
+                                    this.soundOut.Play();
                                 }
-                                this.soundOut.Play();
                             }
+
+
                         }
                     }
                 }
@@ -173,7 +176,7 @@ namespace TextToTalk.Backends
                         if (nextItem.StartTime.HasValue)
                         {
                             var elapsed = Stopwatch.GetElapsedTime(nextItem.StartTime.Value);
-                            Log.Information("Total Latency (Say -> Processing): {Ms}ms", elapsed.TotalMilliseconds);
+                            Log.Information("Total Latency (Say -> PlayPCM): {Ms}", elapsed.TotalMilliseconds);
                         }
 
                         this.soundOut.Play();

--- a/src/TextToTalk/Backends/StreamingSoundQueue.cs
+++ b/src/TextToTalk/Backends/StreamingSoundQueue.cs
@@ -1,0 +1,335 @@
+﻿using NAudio.CoreAudioApi;
+using NAudio.Wave;
+using NAudio.Wave.SampleProviders;
+using Serilog;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Speech.Synthesis;
+using System.Threading;
+using System.Threading.Tasks;
+using TextToTalk.Backends.System;
+using TextToTalk.Lexicons;
+using static TextToTalk.Backends.StreamSoundQueueItem;
+
+namespace TextToTalk.Backends
+{
+
+    public class StreamingSoundQueue(PluginConfiguration config) : SoundQueue<StreamingSoundQueueItem>
+    {
+        // WASAPI Hardware Members
+        private WasapiOut? soundOut;
+        private BufferedWaveProvider? bufferedProvider;
+        private VolumeSampleProvider? volumeProvider;
+        private readonly object soundLock = new();
+
+        // 1. Unified Audio Configuration
+        private static readonly WaveFormat Uberduck = new(22050, 16, 1);
+        private static readonly WaveFormat Wave = new(24000, 16, 1);
+        private static readonly WaveFormat Mp3 = new(24000, 16, 1);
+        private static readonly WaveFormat Azure = new(16000, 16, 1);
+
+        private bool _isDisposed;
+        public CancellationTokenSource? _ttsCts;
+
+        public void EnqueueSound(Stream data, TextSource source, float volume, StreamFormat format, HttpResponseMessage? response)
+        {
+            AddQueueItem(new StreamingSoundQueueItem
+            {
+                Data = data,
+                Source = source,
+                Volume = volume,
+                Format = format,
+                Response = response,
+            });
+        }
+
+        protected override void OnSoundLoop(StreamingSoundQueueItem nextItem)
+        {
+            // 1. Handle Seekable vs Network Streams
+            if (nextItem.Data.CanSeek)
+            {
+                nextItem.Data.Position = 0;
+            }
+
+            // 2. Branch logic based on format (Encoded vs Raw)
+            if (nextItem.Format == StreamFormat.Mp3 || nextItem.Format == StreamFormat.Uberduck)
+            {
+                ProcessMp3Stream(nextItem);
+            }
+            else
+            {
+                ProcessRawPcmStream(nextItem);
+            }
+        }
+
+        private void ProcessMp3Stream(StreamingSoundQueueItem nextItem)
+        {
+            Log.Information("Playing as Mp3)");
+            IMp3FrameDecompressor decompressor = null;
+            try
+            {
+                // Wrap the network stream to support forward-only Position tracking 
+                // and prevent partial-read exceptions in LoadFromStream.
+                using var readFullyStream = new ReadFullyStream(nextItem.Data);
+                Log.Information("Processing as MP3");
+                while (true)
+                {
+
+                    Mp3Frame frame;
+                    try
+                    {
+                        frame = Mp3Frame.LoadFromStream(readFullyStream);
+                    }
+                    catch (Exception) // Catching interruptions here
+                    {
+                        break;
+                    }
+
+                    if (frame == null) break;
+
+                    if (decompressor == null)
+                    {
+                        WaveFormat mp3Format = new Mp3WaveFormat(frame.SampleRate,
+                            frame.ChannelMode == ChannelMode.Mono ? 1 : 2,
+                            frame.FrameLength, frame.BitRate);
+
+                        decompressor = new AcmMp3FrameDecompressor(mp3Format);
+
+                        lock (this.soundLock)
+                        {
+                            EnsureHardwareInitialized(decompressor.OutputFormat);
+                        }
+                    }
+
+                    byte[] decompressedBuffer = new byte[16384 * 2];
+                    int decompressedBytes = decompressor.DecompressFrame(frame, decompressedBuffer, 0);
+                    ApplyVolumeToPcmBuffer(decompressedBuffer, decompressedBytes, nextItem.Volume);
+
+                    if (decompressedBytes > 0)
+                    {
+                        lock (this.soundLock)
+                        {
+                            
+                            this.bufferedProvider.AddSamples(decompressedBuffer, 0, decompressedBytes);
+
+                            if (this.bufferedProvider.BufferedBytes > 4096 &&
+                                this.soundOut.PlaybackState != PlaybackState.Playing)
+                            {
+                                this.soundOut.Play();
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Error during real-time ACM decompression");
+            }
+            finally
+            {
+                decompressor?.Dispose();
+                nextItem.Data.Dispose();
+            }
+        }
+
+        private void ProcessRawPcmStream(StreamingSoundQueueItem nextItem)
+        {
+            Log.Information("Playing as raw PCM");
+            // Resolve format for raw PCM types
+            WaveFormat chunkFormat = nextItem.Format switch
+            {
+                StreamFormat.Wave => Wave,
+                StreamFormat.Azure => Azure,
+                _ => throw new NotSupportedException($"Format {nextItem.Format} requires a decompressor."),
+            };
+
+            lock (this.soundLock)
+            {
+                EnsureHardwareInitialized(chunkFormat);
+
+                // Read in chunks to avoid calling .Length on network streams
+                byte[] chunkBuffer = new byte[16384];
+                int bytesRead;
+                while ((bytesRead = nextItem.Data.Read(chunkBuffer, 0, chunkBuffer.Length)) > 0)
+                {
+                    ApplyVolumeToPcmBuffer(chunkBuffer, bytesRead, nextItem.Volume);
+
+                    this.bufferedProvider.AddSamples(chunkBuffer, 0, bytesRead);
+
+                    if (this.bufferedProvider.BufferedBytes > 512 && this.soundOut.PlaybackState != PlaybackState.Playing)
+                    {
+                        this.soundOut.Play();
+                    }
+                }
+            }
+            nextItem.Data.Dispose();
+        }
+
+        private void EnsureHardwareInitialized(WaveFormat format)
+        {
+            if (this.soundOut == null || !this.bufferedProvider.WaveFormat.Equals(format))
+            {
+                this.StopHardware();
+                this.bufferedProvider = new BufferedWaveProvider(format) { ReadFully = true };
+                this.bufferedProvider.BufferDuration = TimeSpan.FromSeconds(30);
+
+                var mmDevice = GetWasapiDeviceFromGuid(config.SelectedAudioDeviceGuid);
+                this.soundOut = new WasapiOut(mmDevice, AudioClientShareMode.Shared, false, 50);
+                this.soundOut.Init(this.bufferedProvider);
+            }
+        }
+
+        private MMDevice GetWasapiDeviceFromGuid(Guid targetGuid)
+        {
+            using var enumerator = new MMDeviceEnumerator();
+            var devices = enumerator.EnumerateAudioEndPoints(DataFlow.Render, DeviceState.Active);
+            foreach (var device in devices)
+            {
+                if (device.Properties.Contains(PropertyKeys.PKEY_AudioEndpoint_GUID))
+                {
+                    var guidString = device.Properties[PropertyKeys.PKEY_AudioEndpoint_GUID].Value as string;
+                    if (Guid.TryParse(guidString, out var deviceGuid) && deviceGuid == targetGuid)
+                        return device;
+                }
+            }
+            return enumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Console);
+        }
+        protected override void OnSoundCancelled()
+        {
+            StopHardware();
+        }
+        public override void CancelAllSounds()
+        {
+            StopHardware();
+            base.CancelAllSounds();
+        }
+
+        public void StopHardware()
+        {
+            lock (this.soundLock)
+            {
+                if (this.soundOut != null)
+                {
+                    this.soundOut.Stop();
+                    Thread.Sleep(10);
+                    this.soundOut.Dispose();
+                    this.soundOut = null;
+                }
+                if (this.bufferedProvider != null)
+                {
+                    this.bufferedProvider.ClearBuffer();
+                    this.bufferedProvider = null;
+                }
+            }
+
+        }
+        protected override void Dispose(bool disposing)
+        {
+            if (_isDisposed) return;
+            _isDisposed = true; // Signal all loops to stop immediately
+
+            if (disposing)
+            {
+                try
+                {
+                    soundOut?.Stop();
+                }
+                catch (Exception ex)
+                {
+                    DetailedLog.Error(ex, "Error during early shutdown phase");
+                }
+
+                base.Dispose(disposing); // Clean up the queue thread
+                soundOut?.Dispose();
+            }
+        }
+        private void ApplyVolumeToPcmBuffer(byte[] buffer, int bytesRead, float volume)
+        {
+            // Skip calculation if volume is 100% to save CPU
+            if (Math.Abs(volume - 1.0f) < 0.001f) return;
+
+            for (int i = 0; i < bytesRead; i += 2)
+            {
+                // 1. Combine two bytes into one 16-bit signed integer (short)
+                short sample = (short)((buffer[i + 1] << 8) | buffer[i]);
+
+                // 2. Scale the sample value by the volume float (0.0 to 1.0)
+                float scaledSample = sample * volume;
+
+                // 3. Clamp the value to ensure it stays within 16-bit bounds to prevent "pops"
+                if (scaledSample > short.MaxValue) scaledSample = short.MaxValue;
+                if (scaledSample < short.MinValue) scaledSample = short.MinValue;
+
+                short finalSample = (short)scaledSample;
+
+                // 4. Split the 16-bit sample back into two bytes and store in the buffer
+                buffer[i] = (byte)(finalSample & 0xFF);
+                buffer[i + 1] = (byte)((finalSample >> 8) & 0xFF);
+            }
+        }
+    }
+
+    public class ReadFullyStream : Stream
+    {
+        private readonly Stream sourceStream;
+        private long pos;
+
+        public ReadFullyStream(Stream sourceStream)
+        {
+            this.sourceStream = sourceStream;
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            int totalBytesRead = 0;
+            try
+            {
+                while (totalBytesRead < count)
+                {
+                    int bytesRead = sourceStream.Read(buffer, offset + totalBytesRead, count - totalBytesRead);
+                    if (bytesRead == 0) break;
+                    totalBytesRead += bytesRead;
+                }
+            }
+            catch (Exception ex) when (ex.InnerException is SocketException se && se.NativeErrorCode == 10053)
+            {
+                // "An established connection was aborted by the software in your host machine"
+                // This happens when we cancel the TTS request. Return 0 to signal End of Stream.
+                return 0;
+            }
+            catch (IOException)
+            {
+                // General network interruption during skip
+                return 0;
+            }
+
+            pos += totalBytesRead;
+            return totalBytesRead;
+        }
+
+        // Required for the class to compile
+        public override void Write(byte[] buffer, int offset, int count)
+            => throw new NotSupportedException();
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+
+        // We provide a getter for Position so Mp3Frame can track its progress,
+        // but the setter is not supported.
+        public override long Position
+        {
+            get => pos;
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush() { }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+    }
+
+}

--- a/src/TextToTalk/Backends/StreamingSoundQueue.cs
+++ b/src/TextToTalk/Backends/StreamingSoundQueue.cs
@@ -29,10 +29,10 @@ namespace TextToTalk.Backends
         private readonly object soundLock = new();
 
         // 1. Unified Audio Configuration
-        private static readonly WaveFormat Uberduck = new(22050, 16, 1);
+        private static readonly WaveFormat Wave8k = new(8000, 16, 1);
+        private static readonly WaveFormat Wave16k = new(16000, 16, 1);
+        private static readonly WaveFormat Wave22k = new(22050, 16, 1);
         private static readonly WaveFormat Wave = new(24000, 16, 1);
-        private static readonly WaveFormat Mp3 = new(24000, 16, 1);
-        private static readonly WaveFormat Azure = new(16000, 16, 1);
 
         private bool _isDisposed;
         public CancellationTokenSource? _ttsCts;
@@ -61,7 +61,7 @@ namespace TextToTalk.Backends
             }
 
             // 2. Branch logic based on format (Encoded vs Raw)
-            if (nextItem.Format == StreamFormat.Mp3 || nextItem.Format == StreamFormat.Uberduck)
+            if (nextItem.Format == StreamFormat.Mp3)
             {
                 ProcessMp3Stream(nextItem);
             }
@@ -84,14 +84,8 @@ namespace TextToTalk.Backends
                 {
 
                     Mp3Frame frame;
-                    try
-                    {
-                        frame = Mp3Frame.LoadFromStream(readFullyStream);
-                    }
-                    catch (Exception) // Catching interruptions here
-                    {
-                        break;
-                    }
+                    frame = Mp3Frame.LoadFromStream(readFullyStream);
+
 
                     if (frame == null) break;
 
@@ -154,10 +148,9 @@ namespace TextToTalk.Backends
             WaveFormat chunkFormat = nextItem.Format switch
             {
                 StreamFormat.Wave => Wave,
-                StreamFormat.Azure => Azure,
-                StreamFormat.Piper => Uberduck,
-                StreamFormat.PiperLow => Azure,
-                StreamFormat.PiperHigh => Wave,
+                StreamFormat.Wave8K => Wave8k,
+                StreamFormat.Wave16K => Wave16k,
+                StreamFormat.Wave22K => Wave22k,
                 _ => throw new NotSupportedException($"Format {nextItem.Format} requires a decompressor."),
             };
 

--- a/src/TextToTalk/Backends/System/SystemBackend.cs
+++ b/src/TextToTalk/Backends/System/SystemBackend.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Serilog;
+using System;
 using System.Diagnostics;
 using System.Net.Http;
 using System.Threading;

--- a/src/TextToTalk/Backends/System/SystemBackend.cs
+++ b/src/TextToTalk/Backends/System/SystemBackend.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Net.Http;
 using System.Threading;
 
@@ -30,7 +31,9 @@ namespace TextToTalk.Backends.System
         }
         public override void Say(SayRequest request)
         {
-            this.soundQueue.EnqueueSound(request.Voice, request.Source, request.Text);
+            long methodStart = Stopwatch.GetTimestamp();
+            long? timestampToPass = methodStart;
+            this.soundQueue.EnqueueSound(request.Voice, request.Source, request.Text, timestampToPass);
         }
 
         public override void CancelAllSpeech()

--- a/src/TextToTalk/Backends/System/SystemBackend.cs
+++ b/src/TextToTalk/Backends/System/SystemBackend.cs
@@ -59,6 +59,7 @@ namespace TextToTalk.Backends.System
             {
                 this.voiceExceptions.Dispose();
                 this.soundQueue.Dispose();
+
             }
         }
     }

--- a/src/TextToTalk/Backends/System/SystemBackend.cs
+++ b/src/TextToTalk/Backends/System/SystemBackend.cs
@@ -12,9 +12,10 @@ namespace TextToTalk.Backends.System
         private readonly SystemBackendUI ui;
         private readonly SystemSoundQueue soundQueue;
         private readonly IDisposable voiceExceptions;
+        private readonly LatencyTracker latencyTracker;
 
 
-        public SystemBackend(PluginConfiguration config, HttpClient http)
+        public SystemBackend(PluginConfiguration config, HttpClient http, LatencyTracker latencyTracker)
         {
             var lexiconManager = new DalamudLexiconManager();
             LexiconUtils.LoadFromConfigSystem(lexiconManager, config);
@@ -22,8 +23,9 @@ namespace TextToTalk.Backends.System
             this.uiModel = new SystemBackendUIModel();
             this.ui = new SystemBackendUI(this.uiModel, config, lexiconManager, http, this);
 
-            this.soundQueue = new SystemSoundQueue(lexiconManager, config);
+            this.soundQueue = new SystemSoundQueue(lexiconManager, config, latencyTracker);
             this.voiceExceptions = this.uiModel.SubscribeToVoiceExceptions(this.soundQueue.SelectVoiceFailed);
+            this.latencyTracker = latencyTracker;
         }
 
         public override void DrawStyles(IConfigUIDelegates helpers)

--- a/src/TextToTalk/Backends/System/SystemSoundQueue.cs
+++ b/src/TextToTalk/Backends/System/SystemSoundQueue.cs
@@ -5,6 +5,7 @@ using R3;
 using Serilog;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Speech.Synthesis;
 using System.Threading;
@@ -45,13 +46,14 @@ namespace TextToTalk.Backends.System
             }
             return synth;
         }
-        public void EnqueueSound(VoicePreset preset, TextSource source, string text)
+        public void EnqueueSound(VoicePreset preset, TextSource source, string text, long? timeStamp)
         {
             AddQueueItem(new SystemSoundQueueItem
             {
                 Preset = preset,
                 Source = source,
                 Text = text,
+                StartTime = timeStamp,
             });
         }
 
@@ -137,8 +139,12 @@ namespace TextToTalk.Backends.System
                 {
                     if (this.soundOut?.PlaybackState != PlaybackState.Playing)
                     {
+                        if (nextItem.StartTime.HasValue)
+                        {
+                            var elapsed = Stopwatch.GetElapsedTime(nextItem.StartTime.Value);
+                            Log.Information("Total Latency (Say -> Play): {Ms}ms", elapsed.TotalMilliseconds);
+                        }
                         this.soundOut?.Play();
-                        Log.Information("Playing");
                     }
                 }
             }

--- a/src/TextToTalk/Backends/System/SystemSoundQueue.cs
+++ b/src/TextToTalk/Backends/System/SystemSoundQueue.cs
@@ -25,6 +25,7 @@ namespace TextToTalk.Backends.System
         private readonly SpeechSynthesizer _speechSynthesizer;
         private readonly LexiconManager _lexiconManager;
         private readonly PluginConfiguration _config;
+        private readonly LatencyTracker _latencyTracker;
 
 
         private readonly Subject<SelectVoiceFailedException> _selectVoiceFailed = new();
@@ -55,12 +56,12 @@ namespace TextToTalk.Backends.System
             });
         }
 
-        public SystemSoundQueue(LexiconManager lexiconManager, PluginConfiguration config)
+        public SystemSoundQueue(LexiconManager lexiconManager, PluginConfiguration config, LatencyTracker latencyTracker)
         {
             _lexiconManager = lexiconManager;
             _config = config;
             _speechSynthesizer = new SpeechSynthesizer();
-
+            _latencyTracker = latencyTracker;
         }
 
 
@@ -135,7 +136,8 @@ namespace TextToTalk.Backends.System
                         if (nextItem.StartTime.HasValue)
                         {
                             var elapsed = Stopwatch.GetElapsedTime(nextItem.StartTime.Value);
-                            Log.Information("Total Latency (Say -> Play): {Ms}ms", elapsed.TotalMilliseconds);
+                            _latencyTracker.AddLatency(elapsed.TotalMilliseconds);
+                            Log.Debug("Total Latency (Say -> Play): {Ms}ms", elapsed.TotalMilliseconds);
                         }
                         this.soundOut?.Play();
                     }

--- a/src/TextToTalk/Backends/System/SystemSoundQueueItem.cs
+++ b/src/TextToTalk/Backends/System/SystemSoundQueueItem.cs
@@ -8,6 +8,8 @@
 
         public bool Aborted { get; private set; }
 
+        public long? StartTime { get; set; } // Use GetTimestamp() value
+
         internal void Cancel()
         {
             Aborted = true;

--- a/src/TextToTalk/Backends/System/SystemSoundQueueItem.cs
+++ b/src/TextToTalk/Backends/System/SystemSoundQueueItem.cs
@@ -5,5 +5,12 @@
         public VoicePreset Preset { get; set; }
 
         public string Text { get; set; }
+
+        public bool Aborted { get; private set; }
+
+        internal void Cancel()
+        {
+            Aborted = true;
+        }
     }
 }

--- a/src/TextToTalk/Backends/TTSBackend.cs
+++ b/src/TextToTalk/Backends/TTSBackend.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using TextToTalk.Backends.Kokoro;
+using TextToTalk.Backends.Piper;
 
 namespace TextToTalk.Backends
 {
@@ -14,6 +15,7 @@ namespace TextToTalk.Backends
         OpenAi,
         GoogleCloud,
         Kokoro,
+        Piper,
     }
 
     public static class TTSBackendExtensions
@@ -32,6 +34,8 @@ namespace TextToTalk.Backends
                 TTSBackend.GoogleCloud => "Google Cloud",
                 TTSBackend.Kokoro when config != null && KokoroBackend.IsModelFileDownloaded(config) => "Kokoro",
                 TTSBackend.Kokoro => "Kokoro (169MB download required)",
+                TTSBackend.Piper when config != null && PiperBackend.IsModelFileDownloaded(config) => "Piper",
+                TTSBackend.Piper => "Piper (download required)",
                 _ => throw new ArgumentOutOfRangeException(nameof(backend)),
             };
         }
@@ -49,6 +53,7 @@ namespace TextToTalk.Backends
                 TTSBackend.OpenAi => false,
                 TTSBackend.GoogleCloud => false,
                 TTSBackend.Kokoro => false,
+                TTSBackend.Piper => false,
                 _ => throw new ArgumentOutOfRangeException(nameof(backend)),
             };
         }

--- a/src/TextToTalk/Backends/Uberduck/UberduckBackend.cs
+++ b/src/TextToTalk/Backends/Uberduck/UberduckBackend.cs
@@ -14,16 +14,18 @@ public class UberduckBackend : VoiceBackend
     private readonly StreamingSoundQueue soundQueue;
     private readonly UberduckBackendUI ui;
     private readonly UberduckClient? uberduck;
+    private readonly LatencyTracker latencyTracker;
 
-    public UberduckBackend(PluginConfiguration config, HttpClient http)
+    public UberduckBackend(PluginConfiguration config, HttpClient http, LatencyTracker latencyTracker)
     {
         TitleBarColor = ImGui.ColorConvertU32ToFloat4(0xFFDE7312);
 
-        this.soundQueue = new StreamingSoundQueue(config);
+        this.soundQueue = new StreamingSoundQueue(config, latencyTracker);
         this.uberduck = new UberduckClient(this.soundQueue, http);
 
         var voices = this.uberduck.UpdateVoices().GetAwaiter().GetResult();
         this.ui = new UberduckBackendUI(config, this.uberduck, () => voices, this);
+        this.latencyTracker = latencyTracker;
     }
 
     public override void DrawStyles(IConfigUIDelegates helpers)

--- a/src/TextToTalk/Backends/Uberduck/UberduckBackend.cs
+++ b/src/TextToTalk/Backends/Uberduck/UberduckBackend.cs
@@ -11,7 +11,7 @@ namespace TextToTalk.Backends.Uberduck;
 /// </summary>
 public class UberduckBackend : VoiceBackend
 {
-    private readonly StreamSoundQueue soundQueue;
+    private readonly StreamingSoundQueue soundQueue;
     private readonly UberduckBackendUI ui;
     private readonly UberduckClient? uberduck;
 
@@ -19,10 +19,10 @@ public class UberduckBackend : VoiceBackend
     {
         TitleBarColor = ImGui.ColorConvertU32ToFloat4(0xFFDE7312);
 
-        this.soundQueue = new StreamSoundQueue(config);
+        this.soundQueue = new StreamingSoundQueue(config);
         this.uberduck = new UberduckClient(this.soundQueue, http);
 
-        var voices = this.uberduck.GetVoices().GetAwaiter().GetResult();
+        var voices = this.uberduck.UpdateVoices().GetAwaiter().GetResult();
         this.ui = new UberduckBackendUI(config, this.uberduck, () => voices, this);
     }
 

--- a/src/TextToTalk/Backends/Uberduck/UberduckBackend.cs
+++ b/src/TextToTalk/Backends/Uberduck/UberduckBackend.cs
@@ -67,11 +67,21 @@ public class UberduckBackend : VoiceBackend
 
     public override void CancelAllSpeech()
     {
+        if (uberduck._ttsCts != null)
+        {
+            uberduck._ttsCts.Cancel();
+        }
+        this.soundQueue.StopHardware();
         this.soundQueue.CancelAllSounds();
     }
 
     public override void CancelSay(TextSource source)
     {
+        if (uberduck._ttsCts != null)
+        {
+            uberduck._ttsCts.Cancel();
+        }
+        this.soundQueue.StopHardware();
         this.soundQueue.CancelFromSource(source);
     }
 

--- a/src/TextToTalk/Backends/Uberduck/UberduckBackendUI.cs
+++ b/src/TextToTalk/Backends/Uberduck/UberduckBackendUI.cs
@@ -29,8 +29,7 @@ public class UberduckBackendUI
         var credentials = UberduckCredentialManager.LoadCredentials();
         if (credentials != null)
         {
-            this.apiKey = credentials.UserName;
-            this.apiSecret = credentials.Password;
+            this.apiKey = credentials.Password;
         }
 
         this.uberduck.ApiKey = this.apiKey;
@@ -52,11 +51,11 @@ public class UberduckBackendUI
 
         if (ImGui.Button($"Save and Login##{MemoizedId.Create()}"))
         {
-            var username = Whitespace.Replace(this.apiKey, "");
-            var password = Whitespace.Replace(this.apiSecret, "");
-            UberduckCredentialManager.SaveCredentials(username, password);
-            this.uberduck.ApiKey = username;
-            this.uberduck.ApiSecret = password;
+            var apiKey = Whitespace.Replace(this.apiKey, "");
+            //var password = Whitespace.Replace(this.apiSecret, "");
+            UberduckCredentialManager.SaveCredentials(apiKey);
+            this.uberduck.ApiKey = apiKey;
+            //this.uberduck.ApiSecret = password;
         }
 
         ImGui.SameLine();

--- a/src/TextToTalk/Backends/Uberduck/UberduckBackendUI.cs
+++ b/src/TextToTalk/Backends/Uberduck/UberduckBackendUI.cs
@@ -52,10 +52,8 @@ public class UberduckBackendUI
         if (ImGui.Button($"Save and Login##{MemoizedId.Create()}"))
         {
             var apiKey = Whitespace.Replace(this.apiKey, "");
-            //var password = Whitespace.Replace(this.apiSecret, "");
             UberduckCredentialManager.SaveCredentials(apiKey);
             this.uberduck.ApiKey = apiKey;
-            //this.uberduck.ApiSecret = password;
         }
 
         ImGui.SameLine();

--- a/src/TextToTalk/Backends/Uberduck/UberduckBackendUI.cs
+++ b/src/TextToTalk/Backends/Uberduck/UberduckBackendUI.cs
@@ -116,21 +116,32 @@ public class UberduckBackendUI
             var voiceCategoriesFlat = voiceCategories.SelectMany(vc => vc.Value).ToList();
             var voiceDisplayNames = voiceCategoriesFlat.Select(v => v.DisplayName).ToArray();
             var voiceIds = voiceCategoriesFlat.Select(v => v.Name).ToArray();
+            // 1. Get the index
             var voiceIndex = Array.IndexOf(voiceIds, currentVoicePreset.VoiceName);
-            if (ImGui.BeginCombo($"Voice##{MemoizedId.Create()}", voiceDisplayNames[voiceIndex]))
+
+            // 2. Validate the index and determine the text to show in the combo box
+            // If -1, we show a placeholder or the raw name instead of crashing
+            string previewValue = (voiceIndex >= 0 && voiceIndex < voiceDisplayNames.Length)
+                ? voiceDisplayNames[voiceIndex]
+                : "Select a voice..."; // Fallback text
+
+            if (ImGui.BeginCombo($"Voice##{MemoizedId.Create()}", previewValue))
             {
                 foreach (var (category, voices) in voiceCategories)
                 {
                     ImGui.Selectable(category, false, ImGuiSelectableFlags.Disabled);
                     foreach (var voice in voices)
                     {
-                        if (ImGui.Selectable($"  {voice.DisplayName}"))
+                        // Highlight the currently selected item
+                        bool isSelected = voice.Name == currentVoicePreset.VoiceName;
+
+                        if (ImGui.Selectable($"  {voice.DisplayName}##{voice.Name}", isSelected))
                         {
                             currentVoicePreset.VoiceName = voice.Name;
                             this.config.Save();
                         }
 
-                        if (voice.Name == currentVoicePreset.VoiceName)
+                        if (isSelected)
                         {
                             ImGui.SetItemDefaultFocus();
                         }

--- a/src/TextToTalk/Backends/Uberduck/UberduckClient.cs
+++ b/src/TextToTalk/Backends/Uberduck/UberduckClient.cs
@@ -83,7 +83,7 @@ public partial class UberduckClient
                 var waveStream = new MemoryStream(audioBytes);
                 long? timestampToPass = methodStart;
 
-                this.soundQueue.EnqueueSound(waveStream, source, volume, StreamFormat.Uberduck, null, timestampToPass);
+                this.soundQueue.EnqueueSound(waveStream, source, volume, StreamFormat.Mp3, null, timestampToPass);
             }
         }
     }
@@ -143,6 +143,8 @@ public partial class UberduckClient
             {
                 Log.Information($"Response = {response.StatusCode}");
             }
+        }
+        else {             Log.Information("Authorization not set, cannot update voices.");
         }
 
         return new Dictionary<string, IList<UberduckVoice>>();

--- a/src/TextToTalk/Backends/Uberduck/UberduckClient.cs
+++ b/src/TextToTalk/Backends/Uberduck/UberduckClient.cs
@@ -4,6 +4,7 @@ using Serilog;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -45,6 +46,7 @@ public partial class UberduckClient
 
     public async Task Say(string voice, int playbackRate, float volume, TextSource source, string text)
     {
+        long methodStart = Stopwatch.GetTimestamp();
         var url = "https://api.uberduck.ai/v1/text-to-speech";
 
         var payload = new
@@ -72,10 +74,10 @@ public partial class UberduckClient
 
                 // Use a MemoryStream to hold the downloaded data
                 var waveStream = new MemoryStream(audioBytes);
-
+                long? timestampToPass = methodStart;
                 // Pass the stream to your queue. Ensure the consumer uses WaveFileReader 
                 // to correctly handle the WAV container.
-                this.soundQueue.EnqueueSound(waveStream, source, volume, StreamFormat.Uberduck, null);
+                this.soundQueue.EnqueueSound(waveStream, source, volume, StreamFormat.Uberduck, null, timestampToPass);
             }
         }
     }

--- a/src/TextToTalk/Backends/Uberduck/UberduckCredentialManager.cs
+++ b/src/TextToTalk/Backends/Uberduck/UberduckCredentialManager.cs
@@ -13,9 +13,9 @@ public static class UberduckCredentialManager
         return credentials;
     }
 
-    public static void SaveCredentials(string username, string password)
+    public static void SaveCredentials(string apikey)//, string password)
     {
-        var credentials = new NetworkCredential(username, password);
+        var credentials = new NetworkCredential("null", apikey);//, password);
         CredentialManager.SaveCredentials(CredentialsTarget, credentials);
     }
 

--- a/src/TextToTalk/Backends/Uberduck/UberduckVoice.cs
+++ b/src/TextToTalk/Backends/Uberduck/UberduckVoice.cs
@@ -1,14 +1,33 @@
 ﻿using Newtonsoft.Json;
+using System.Collections.Generic;
 
 namespace TextToTalk.Backends.Uberduck;
 
 public class UberduckVoice
 {
-    [JsonProperty("display_name")] public required string DisplayName { get; init; }
+    [JsonProperty("display_name")]
+    public required string DisplayName { get; init; }
 
-    [JsonProperty("name")] public required string Name { get; init; }
+    [JsonProperty("name")]
+    public required string Name { get; init; }
 
-    [JsonProperty("voicemodel_uuid")] public required string VoiceModelUuid { get; init; }
+    [JsonProperty("voicemodel_uuid")]
+    public required string VoiceModelUuid { get; init; }
 
-    [JsonProperty("category")] public required string? Category { get; init; }
+    [JsonProperty("category")]
+    public string? Category { get; init; }
+
+    // New for 2026: Useful for filtering by locale
+    [JsonProperty("language")]
+    public string? Language { get; init; }
+
+    // New for 2026: Contains traits like "professional", "narrative", etc.
+    [JsonProperty("tags")]
+    public List<string> Tags { get; init; } = new();
+}
+
+public class UberduckVoiceResponse
+{
+    [JsonProperty("voices")]
+    public IList<UberduckVoice> Voices { get; set; }
 }

--- a/src/TextToTalk/Backends/VoiceBackendManager.cs
+++ b/src/TextToTalk/Backends/VoiceBackendManager.cs
@@ -24,17 +24,20 @@ namespace TextToTalk.Backends
         private readonly PluginConfiguration config;
         private readonly IUiBuilder uiBuilder;
         private readonly INotificationService notificationService;
+        private readonly LatencyTracker latencyTracker;
 
         public VoiceBackend? Backend { get; private set; }
         public bool BackendLoading { get; private set; }
 
         public VoiceBackendManager(PluginConfiguration config, HttpClient http, IUiBuilder uiBuilder,
-            INotificationService notificationService)
+            INotificationService notificationService, LatencyTracker tracker)
         {
             this.config = config;
             this.http = http;
             this.uiBuilder = uiBuilder;
             this.notificationService = notificationService;
+            this.latencyTracker = tracker;
+
 
             SetBackend(this.config.Backend);           
         }
@@ -105,16 +108,16 @@ namespace TextToTalk.Backends
         {
             return backendKind switch
             {
-                TTSBackend.System => new SystemBackend(this.config, this.http),
-                TTSBackend.Websocket => new WebsocketBackend(this.config, this.notificationService),
-                TTSBackend.AmazonPolly => new PollyBackend(this.config, this.http),
-                TTSBackend.Uberduck => new UberduckBackend(this.config, this.http),
-                TTSBackend.Azure => new AzureBackend(this.config, this.http),
-                TTSBackend.ElevenLabs => new ElevenLabsBackend(this.config, this.http, this.notificationService),
-                TTSBackend.OpenAi => new OpenAiBackend(this.config, this.http, this.notificationService),
-                TTSBackend.GoogleCloud => new GoogleCloudBackend(this.config),
-                TTSBackend.Kokoro => new KokoroBackend(this.config),
-                TTSBackend.Piper => new PiperBackend(this.config),
+                TTSBackend.System => new SystemBackend(this.config, this.http, this.latencyTracker),
+                TTSBackend.Websocket => new WebsocketBackend(this.config, this.notificationService, this.latencyTracker),
+                TTSBackend.AmazonPolly => new PollyBackend(this.config, this.http, this.latencyTracker),
+                TTSBackend.Uberduck => new UberduckBackend(this.config, this.http, this.latencyTracker),
+                TTSBackend.Azure => new AzureBackend(this.config, this.http, this.latencyTracker),
+                TTSBackend.ElevenLabs => new ElevenLabsBackend(this.config, this.http, this.notificationService, this.latencyTracker),
+                TTSBackend.OpenAi => new OpenAiBackend(this.config, this.http, this.notificationService, this.latencyTracker),
+                TTSBackend.GoogleCloud => new GoogleCloudBackend(this.config, this.latencyTracker),
+                TTSBackend.Kokoro => new KokoroBackend(this.config, this.latencyTracker),
+                TTSBackend.Piper => new PiperBackend(this.config, this.latencyTracker),
                 _ => throw new ArgumentOutOfRangeException(nameof(backendKind)),
             };
         }

--- a/src/TextToTalk/Backends/VoiceBackendManager.cs
+++ b/src/TextToTalk/Backends/VoiceBackendManager.cs
@@ -9,6 +9,7 @@ using TextToTalk.Backends.ElevenLabs;
 using TextToTalk.Backends.GoogleCloud;
 using TextToTalk.Backends.Kokoro;
 using TextToTalk.Backends.OpenAI;
+using TextToTalk.Backends.Piper;
 using TextToTalk.Backends.Polly;
 using TextToTalk.Backends.System;
 using TextToTalk.Backends.Uberduck;
@@ -113,6 +114,7 @@ namespace TextToTalk.Backends
                 TTSBackend.OpenAi => new OpenAiBackend(this.config, this.http, this.notificationService),
                 TTSBackend.GoogleCloud => new GoogleCloudBackend(this.config),
                 TTSBackend.Kokoro => new KokoroBackend(this.config),
+                TTSBackend.Piper => new PiperBackend(this.config),
                 _ => throw new ArgumentOutOfRangeException(nameof(backendKind)),
             };
         }

--- a/src/TextToTalk/Backends/Websocket/WebsocketBackend.cs
+++ b/src/TextToTalk/Backends/Websocket/WebsocketBackend.cs
@@ -23,7 +23,9 @@ public class WebsocketBackend : VoiceBackend
     private bool dirtyConfig;
     private Exception? lastException;
 
-    public WebsocketBackend(PluginConfiguration config, INotificationService notificationService)
+    private readonly LatencyTracker latencyTracker;
+
+    public WebsocketBackend(PluginConfiguration config, INotificationService notificationService, LatencyTracker latencyTracker)
     {
         this.config = config;
 
@@ -40,6 +42,7 @@ public class WebsocketBackend : VoiceBackend
         }
 
         this.wsServer.Start();
+        this.latencyTracker = latencyTracker;
     }
 
     public override void DrawStyles(IConfigUIDelegates helpers)

--- a/src/TextToTalk/CommandModules/MainCommandModule.cs
+++ b/src/TextToTalk/CommandModules/MainCommandModule.cs
@@ -14,9 +14,10 @@ public class MainCommandModule : CommandModule
     private readonly ConfigurationWindow configurationWindow;
     private readonly IConfigUIDelegates configUIDelegates;
     private readonly VoiceStyles StylesWindow;
+    private readonly StatsWindow StatsWindow;
 
     public MainCommandModule(ICommandManager commandManager, IChatGui chat, PluginConfiguration config,
-        VoiceBackendManager backendManager, ConfigurationWindow configurationWindow, IConfigUIDelegates configUIDelegates, VoiceStyles StylesWindow) : base(commandManager) //ElevenLabsStylesWindow elevenLabsStylesWindow)
+        VoiceBackendManager backendManager, ConfigurationWindow configurationWindow, IConfigUIDelegates configUIDelegates, VoiceStyles StylesWindow, StatsWindow statsWindow) : base(commandManager) //ElevenLabsStylesWindow elevenLabsStylesWindow)
     {
         this.chat = chat;
 
@@ -25,6 +26,7 @@ public class MainCommandModule : CommandModule
         this.configurationWindow = configurationWindow;
         this.configUIDelegates = configUIDelegates;
         this.StylesWindow = StylesWindow;
+        this.StatsWindow = statsWindow;
 
         AddCommand("/canceltts", CancelTts, "Cancel all queued TTS messages.");
         AddCommand("/toggletts", ToggleTts, "Toggle TextToTalk's text-to-speech.");
@@ -32,6 +34,8 @@ public class MainCommandModule : CommandModule
         AddCommand("/enabletts", EnableTts, "Enable TextToTalk's text-to-speech.");
         AddCommand("/tttconfig", ToggleConfig, "Toggle TextToTalk's configuration window.");
         AddCommand("/tttstyles", ToggleStyles, "Toggle TextToTalk's styles window.");
+        AddCommand("/tttstats", ToggleStats, "Toggle TextToTalk's latency stats window.");
+        
     }
 
     public void CancelTts(string command = "", string args = "")
@@ -69,5 +73,10 @@ public class MainCommandModule : CommandModule
     public void ToggleStyles(string command = "", string args = "")
     {
         this.StylesWindow.Toggle();
+    }
+
+    public void ToggleStats(string command = "", string args = "")
+    {
+        this.StatsWindow.Toggle();
     }
 }

--- a/src/TextToTalk/GameEnums/AdditionalChatType.cs
+++ b/src/TextToTalk/GameEnums/AdditionalChatType.cs
@@ -10,7 +10,7 @@
         Gathering = 67,
         FCAnnouncement = 69,
         FCLogin = 70,
-        RetainerSale = 71,
+        //RetainerSale = 71,
         PartyFinderState = 72,
         ActionUsedOnYou = 2091,
         FailedActionUsedOnYou = 2218,

--- a/src/TextToTalk/PluginConfiguration.cs
+++ b/src/TextToTalk/PluginConfiguration.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Threading;
 using TextToTalk.Backends;
 using TextToTalk.Backends.System;
 using TextToTalk.Backends.Websocket;

--- a/src/TextToTalk/TextProviders/ChatMessageHandler.cs
+++ b/src/TextToTalk/TextProviders/ChatMessageHandler.cs
@@ -127,12 +127,14 @@ public class ChatMessageHandler : IChatMessageHandler
         if (!this.filters.OnlyMessagesFromYou(speaker?.Name.TextValue ?? sender.TextValue)) return;
 
         if (!this.filters.ShouldSayFromYou(speaker?.Name.TextValue ?? sender.TextValue)) return;
+        
+        else if (type == XivChatType.TellOutgoing && config.SkipMessagesFromYou == true) return;
 
-        OnTextEmit.Invoke(new ChatTextEmitEvent(
-            GetCleanSpeakerName(speaker, sender),
-            textValue,
-            speaker,
-            type));
+            OnTextEmit.Invoke(new ChatTextEmitEvent(
+                GetCleanSpeakerName(speaker, sender),
+                textValue,
+                speaker,
+                type));
     }
 
     private static SeString GetCleanSpeakerName(IGameObject? speaker, SeString sender)

--- a/src/TextToTalk/TextToTalk.cs
+++ b/src/TextToTalk/TextToTalk.cs
@@ -23,6 +23,7 @@ using TextToTalk.Backends.ElevenLabs;
 using TextToTalk.Backends.GoogleCloud;
 using TextToTalk.Backends.Kokoro;
 using TextToTalk.Backends.OpenAI;
+using TextToTalk.Backends.Piper;
 using TextToTalk.Backends.Polly;
 using TextToTalk.Backends.System;
 using TextToTalk.Backends.Uberduck;
@@ -507,6 +508,7 @@ namespace TextToTalk
                 OpenAiBackend => GetVoiceForSpeaker<OpenAiVoicePreset>(name, gender),
                 GoogleCloudBackend => GetVoiceForSpeaker<GoogleCloudVoicePreset>(name, gender),
                 KokoroBackend => GetVoiceForSpeaker<KokoroVoicePreset>(name, gender),
+                PiperBackend => GetVoiceForSpeaker<PiperVoicePreset>(name, gender),
                 _ => throw new InvalidOperationException("Failed to get voice preset for backend."),
             };
         }

--- a/src/TextToTalk/TextToTalk.cs
+++ b/src/TextToTalk/TextToTalk.cs
@@ -44,6 +44,8 @@ using TextToTalk.Utils;
 using static System.Net.Mime.MediaTypeNames;
 using GameObject = Dalamud.Game.ClientState.Objects.Types.IGameObject;
 
+using Serilog;
+
 namespace TextToTalk
 {
     public partial class TextToTalk : IDalamudPlugin

--- a/src/TextToTalk/TextToTalk.csproj
+++ b/src/TextToTalk/TextToTalk.csproj
@@ -42,6 +42,7 @@
         <PackageReference Include="Microsoft.Win32.Registry" Version="4.3.0" />
         <PackageReference Include="NAudio" Version="2.2.1" />
         <PackageReference Include="OpenAI" Version="2.8.0" />
+        <PackageReference Include="PiperSharp" Version="1.0.6" />
         <PackageReference Include="R3" Version="1.2.9" />
         <PackageReference Include="Riok.Mapperly" Version="4.1.0" ExcludeAssets="runtime" PrivateAssets="all">
           <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/TextToTalk/TextToTalk.csproj
+++ b/src/TextToTalk/TextToTalk.csproj
@@ -23,6 +23,11 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <Compile Remove="Backends\Azure\RawStreamingSoundQueueAzure.cs" />
+      <Compile Remove="Backends\RawStreamingSoundQueue.cs" />
+    </ItemGroup>
+
+    <ItemGroup>
         <Content Include="..\..\images\icon.png" Link="images\icon.png">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </Content>
@@ -31,11 +36,12 @@
     <ItemGroup>
         <PackageReference Include="AdysTech.CredentialManager" Version="2.6.0" />
         <PackageReference Include="AWSSDK.Polly" Version="3.7.401.37" />
-        <PackageReference Include="Google.Cloud.TextToSpeech.V1" Version="3.9.0" />
+        <PackageReference Include="Google.Cloud.TextToSpeech.V1" Version="3.17.0" />
         <PackageReference Include="KokoroSharp.CPU" Version="0.6.1" />
         <PackageReference Include="Microsoft.CognitiveServices.Speech" Version="1.41.1" />
         <PackageReference Include="Microsoft.Win32.Registry" Version="4.3.0" />
         <PackageReference Include="NAudio" Version="2.2.1" />
+        <PackageReference Include="OpenAI" Version="2.8.0" />
         <PackageReference Include="R3" Version="1.2.9" />
         <PackageReference Include="Riok.Mapperly" Version="4.1.0" ExcludeAssets="runtime" PrivateAssets="all">
           <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/TextToTalk/UI/ConfigurationWindow.cs
+++ b/src/TextToTalk/UI/ConfigurationWindow.cs
@@ -1,19 +1,20 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Numerics;
-using System.Text;
+﻿using Dalamud.Bindings.ImGui;
 using Dalamud.Game.Text;
 using Dalamud.Interface;
 using Dalamud.Interface.Windowing;
 using Dalamud.Plugin.Services;
-using Dalamud.Bindings.ImGui;
 using Lumina.Excel.Sheets;
 using R3;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Text;
 using TextToTalk.Backends;
 using TextToTalk.Data.Model;
 using TextToTalk.GameEnums;
 using TextToTalk.Services;
+using TextToTalk.UI.Windows;
 
 namespace TextToTalk.UI
 {
@@ -295,6 +296,12 @@ namespace TextToTalk.UI
                     this.config);
                 Components.Tooltip(
                     "Removes \"stuttering\" from NPC dialogue such as \"H-hello, nice to m-meet you...\"");
+
+                
+                if (ImGui.Button($"Show Latency Data##{MemoizedId.Create()}"))
+                {
+                    StatsWindow.Instance?.ToggleStats();
+                }
             }
         }
 

--- a/src/TextToTalk/UI/Windows/StatsWindow.cs
+++ b/src/TextToTalk/UI/Windows/StatsWindow.cs
@@ -1,0 +1,51 @@
+﻿using Dalamud.Bindings.ImGui;
+using Dalamud.Interface.Windowing;
+using System;
+using System.Linq;
+using TextToTalk;
+using TextToTalk.Backends;
+
+public class StatsWindow : Window
+{
+    private float[] dataArray = Array.Empty<float>();
+    private DateTime lastUpdateTime = DateTime.MinValue;
+    private readonly object updateLock = new();
+
+    public interface IWindowController
+    {
+        void ToggleStats();
+    }
+
+    private readonly LatencyTracker tracker;
+    public bool IsVisible = false;
+
+    public StatsWindow(TextToTalk.LatencyTracker tracker) : base("TTS Statistics")
+    {
+        this.tracker = tracker;
+    }
+
+    public override void Draw()
+    {
+        float[] fullDataArray = tracker.GetHistoryArray();
+
+        ImGui.Text($"Average Latency: {tracker.AverageLatency:F2} ms");
+        ImGui.SameLine();
+        if (ImGui.Button("Clear History"))
+        {
+            tracker.Clear();
+        }
+
+        if (ImGui.TreeNode("View Raw History"))
+        {
+            if (ImGui.BeginChild("RawDataList", new System.Numerics.Vector2(0, 150)))
+            {
+                for (int i = 0; i < fullDataArray.Length; i++)
+                {
+                    ImGui.Text($"[{i:000}] {fullDataArray[i]:F2} ms");
+                }
+                ImGui.EndChild();
+            }
+            ImGui.TreePop();
+        }
+    }
+}

--- a/src/TextToTalk/UI/Windows/StatsWindow.cs
+++ b/src/TextToTalk/UI/Windows/StatsWindow.cs
@@ -37,12 +37,15 @@ public class StatsWindow : Window
 
         if (ImGui.TreeNode("View Raw History"))
         {
-            if (ImGui.BeginChild("RawDataList", new System.Numerics.Vector2(0, 150)))
+            // *** REFACTORED: Use the boolean 'true' for drawing a border ***
+            // The signature now accepts a boolean instead of ImGuiChildFlags
+            if (ImGui.BeginChild("RawDataList", new System.Numerics.Vector2(0, 150), true)) // The 'true' draws the border
             {
                 for (int i = 0; i < fullDataArray.Length; i++)
                 {
                     ImGui.Text($"[{i:000}] {fullDataArray[i]:F2} ms");
                 }
+
                 ImGui.EndChild();
             }
             ImGui.TreePop();

--- a/src/TextToTalk/UI/Windows/StatsWindow.cs
+++ b/src/TextToTalk/UI/Windows/StatsWindow.cs
@@ -4,17 +4,14 @@ using System;
 using System.Linq;
 using TextToTalk;
 using TextToTalk.Backends;
+using TextToTalk.UI.Windows;
 
 public class StatsWindow : Window
 {
     private float[] dataArray = Array.Empty<float>();
     private DateTime lastUpdateTime = DateTime.MinValue;
     private readonly object updateLock = new();
-
-    public interface IWindowController
-    {
-        void ToggleStats();
-    }
+    public static StatsWindow? Instance { get; private set; }
 
     private readonly LatencyTracker tracker;
     public bool IsVisible = false;
@@ -22,6 +19,12 @@ public class StatsWindow : Window
     public StatsWindow(TextToTalk.LatencyTracker tracker) : base("TTS Statistics")
     {
         this.tracker = tracker;
+        Instance = this;
+    }
+
+    public void ToggleStats()
+    {
+        this.IsOpen = !this.IsOpen;
     }
 
     public override void Draw()
@@ -37,9 +40,7 @@ public class StatsWindow : Window
 
         if (ImGui.TreeNode("View Raw History"))
         {
-            // *** REFACTORED: Use the boolean 'true' for drawing a border ***
-            // The signature now accepts a boolean instead of ImGuiChildFlags
-            if (ImGui.BeginChild("RawDataList", new System.Numerics.Vector2(0, 150), true)) // The 'true' draws the border
+            if (ImGui.BeginChild("RawDataList", new System.Numerics.Vector2(0, 150), true))
             {
                 for (int i = 0; i < fullDataArray.Length; i++)
                 {

--- a/src/TextToTalk/UI/Windows/StylesWindow.cs
+++ b/src/TextToTalk/UI/Windows/StylesWindow.cs
@@ -29,11 +29,6 @@ namespace TextToTalk.UI.Windows
         void Draw(IConfigUIDelegates helpers);
     }
 
-    public interface IWindowController
-    {
-        void ToggleStyle();
-    }
-
     public class VoiceStyles : Window
     {
         private readonly VoiceBackendManager backendManager;

--- a/src/TextToTalk/VoicePresetConfiguration.cs
+++ b/src/TextToTalk/VoicePresetConfiguration.cs
@@ -1,14 +1,15 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Newtonsoft.Json;
 using TextToTalk.Backends;
 using TextToTalk.Backends.Azure;
 using TextToTalk.Backends.ElevenLabs;
 using TextToTalk.Backends.GoogleCloud;
 using TextToTalk.Backends.Kokoro;
 using TextToTalk.Backends.OpenAI;
+using TextToTalk.Backends.Piper;
 using TextToTalk.Backends.Polly;
 using TextToTalk.Backends.System;
 using TextToTalk.Backends.Uberduck;
@@ -268,6 +269,17 @@ public class VoicePresetConfiguration
                 Name = GetNullableValue<string?>(corrupted, "Name"),
                 InternalName = GetNullableValue<string?>(corrupted, "InternalName"),
                 EnabledBackend = TTSBackend.Kokoro
+            },
+            TTSBackend.Piper => new PiperVoicePreset
+            {
+                Id = Convert.ToInt32(GetNullableValue<long?>(corrupted, "Id")),
+                Speed = Convert.ToSingle(GetNullableValue<double?>(corrupted, "Speed")),
+                Volume = Convert.ToSingle(GetNullableValue<double?>(corrupted, "Volume")),
+                Name = GetNullableValue<string?>(corrupted, "Name"),
+                InternalName = GetNullableValue<string?>(corrupted, "InternalName"),
+                ModelPath = GetNullableValue<string?>(corrupted, "ModelPath"),
+
+                EnabledBackend = TTSBackend.Piper
             },
             _ => throw new ArgumentOutOfRangeException($"{backendCorrupt}"),
         };

--- a/src/TextToTalk/VoicePresetConfiguration.cs
+++ b/src/TextToTalk/VoicePresetConfiguration.cs
@@ -254,8 +254,6 @@ public class VoicePresetConfiguration
                 Id = Convert.ToInt32(GetNullableValue<long?>(corrupted, "Id")),
                 Name = GetNullableValue<string?>(corrupted, "Name"),
                 Gender = GetNullableValue<string?>(corrupted, "Gender"),
-                SampleRate = Convert.ToInt32(GetNullableValue<long?>(corrupted, "SampleRate")),
-                Pitch = Convert.ToSingle(GetNullableValue<double?>(corrupted, "Pitch")),
                 PlaybackRate = Convert.ToSingle(GetNullableValue<double?>(corrupted, "PlaybackRate")),
                 Volume = Convert.ToSingle(GetNullableValue<double?>(corrupted, "Volume")),
                 Locale = GetNullableValue<string?>(corrupted, "Locale"),

--- a/src/TextToTalk/packages.lock.json
+++ b/src/TextToTalk/packages.lock.json
@@ -31,12 +31,12 @@
       },
       "Google.Cloud.TextToSpeech.V1": {
         "type": "Direct",
-        "requested": "[3.9.0, )",
-        "resolved": "3.9.0",
-        "contentHash": "JpejhPzzEQ6rdaf0nsjjJwj1CJb8Zs0x+TH27+A17KF2g0NqrgtAbpkUZTiGlQHhOzJSF1lB3amrQhbGjozJ3A==",
+        "requested": "[3.17.0, )",
+        "resolved": "3.17.0",
+        "contentHash": "27vM1NEBmCqAwqagwS0aEHfRBrFy7z6Ef+BblwKMaxtUUY0amdUdeXLY/PU8RSIHtJoan1K6ZKIS6YYqzgp77g==",
         "dependencies": {
-          "Google.Api.Gax.Grpc": "[4.9.0, 5.0.0)",
-          "Google.LongRunning": "[3.3.0, 4.0.0)"
+          "Google.Api.Gax.Grpc": "[4.12.1, 5.0.0)",
+          "Google.LongRunning": "[3.5.0, 4.0.0)"
         }
       },
       "KokoroSharp.CPU": {
@@ -75,6 +75,15 @@
           "NAudio.Midi": "2.2.1",
           "NAudio.Wasapi": "2.2.1",
           "NAudio.WinMM": "2.2.1"
+        }
+      },
+      "OpenAI": {
+        "type": "Direct",
+        "requested": "[2.8.0, )",
+        "resolved": "2.8.0",
+        "contentHash": "KcYpZ9IhuxFD2hGAJlL5vABtkr00CjeJU0SY8CjZQyzvzkzLop8jhdX3iDvteVJg6e3y4TEiY+Kti4gDJAagnA==",
+        "dependencies": {
+          "System.ClientModel": "1.8.1"
         }
       },
       "R3": {
@@ -135,103 +144,103 @@
       },
       "Google.Api.CommonProtos": {
         "type": "Transitive",
-        "resolved": "2.16.0",
-        "contentHash": "37MuZrE9AAqHAdYgFLoTHydAiXDRriQZGVKEg6fr6ASnrY5GtauYXnQrGk5x2K3NmYzEXe+wkpaPVmxjb3NKjg==",
+        "resolved": "2.17.0",
+        "contentHash": "elfQPknFr495hm7vdy6ZlgyQh6yzZq9TU7sS35L/Fj/fqjM/mUGau9gVJLhvQEtUlPjtR80hpn/m9HvBMyCXIw==",
         "dependencies": {
-          "Google.Protobuf": "[3.28.2, 4.0.0)"
+          "Google.Protobuf": "[3.31.1, 4.0.0]"
         }
       },
       "Google.Api.Gax": {
         "type": "Transitive",
-        "resolved": "4.9.0",
-        "contentHash": "fjHHYcQ99u0ztqwT537rvVtJMdDy6G2VHBZ+F1cBjDGYNVZfrpk40DMQ/OpUGToT9ZGHVirhh3eJ73bw2ANVPQ==",
+        "resolved": "4.12.1",
+        "contentHash": "G62dRNOv5DolfRviT6CCrL2a5nZ/CWWdRzhADkGnpCkYSOc3QnH5xxRvZiOKuHU8weJ/pAqAqrj7+T9IWdlu2Q==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
-          "Newtonsoft.Json": "13.0.3"
+          "Newtonsoft.Json": "13.0.4"
         }
       },
       "Google.Api.Gax.Grpc": {
         "type": "Transitive",
-        "resolved": "4.9.0",
-        "contentHash": "ToCx/0cs+wJ9j7vzKRcPAKneJVZrz/s9JhW9QsFx1dar9WzTxawQZ8xTjyieSy8tY0UiYCL1qYkn/iRrklYnSA==",
+        "resolved": "4.12.1",
+        "contentHash": "W3LjuitOWxWyvbwqeHvpgp0LdshEiTnw/pneDAfAhQ02VgU2gVEzSXfGNPsvL8hDPBXjngR/fWNme8Kungwwkw==",
         "dependencies": {
-          "Google.Api.CommonProtos": "2.16.0",
-          "Google.Api.Gax": "4.9.0",
-          "Google.Apis.Auth": "1.68.0",
-          "Grpc.Auth": "2.66.0",
-          "Grpc.Core.Api": "2.66.0",
-          "Grpc.Net.Client": "2.66.0",
+          "Google.Api.CommonProtos": "2.17.0",
+          "Google.Api.Gax": "4.12.1",
+          "Google.Apis.Auth": "1.72.0",
+          "Grpc.Auth": "[2.71.0, 3.0.0)",
+          "Grpc.Core.Api": "[2.71.0, 3.0.0)",
+          "Grpc.Net.Client": "[2.71.0, 3.0.0)",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0"
         }
       },
       "Google.Apis": {
         "type": "Transitive",
-        "resolved": "1.68.0",
-        "contentHash": "s2MymhdpH+ybZNBeZ2J5uFgFHApBp+QXf9FjZSdM1lk/vx5VqIknJwnaWiuAzXxPrLEkesX0Q+UsiWn39yZ9zw==",
+        "resolved": "1.72.0",
+        "contentHash": "QbSJ08W7QuqsfzDPOZDHl1aFzCYwMcfBoHqQRh7koglwDN5WacShCKYMpU/zR1Pf3h3sH6JTGEeM/txAxaJuEg==",
         "dependencies": {
-          "Google.Apis.Core": "1.68.0"
+          "Google.Apis.Core": "1.72.0"
         }
       },
       "Google.Apis.Auth": {
         "type": "Transitive",
-        "resolved": "1.68.0",
-        "contentHash": "hFx8Qz5bZ4w0hpnn4tSmZaaFpjAMsgVElZ+ZgVLUZ2r9i+AKcoVgwiNfv1pruNS5cCvpXqhKECbruBCfRezPHA==",
+        "resolved": "1.72.0",
+        "contentHash": "RBoFwFKBHKUjuyJf2weEnqICQLaY0TdIrdFv2yC8bsiR2VFYxizOn3C/qN1FWCCb0Uh9GhW+zwAV1yUxPjiocw==",
         "dependencies": {
-          "Google.Apis": "1.68.0",
-          "Google.Apis.Core": "1.68.0",
+          "Google.Apis": "1.72.0",
+          "Google.Apis.Core": "1.72.0",
           "System.Management": "7.0.2"
         }
       },
       "Google.Apis.Core": {
         "type": "Transitive",
-        "resolved": "1.68.0",
-        "contentHash": "pAqwa6pfu53UXCR2b7A/PAPXeuVg6L1OFw38WckN27NU2+mf+KTjoEg2YGv/f0UyKxzz7DxF1urOTKg/6dTP9g==",
+        "resolved": "1.72.0",
+        "contentHash": "ZmYX1PU0vTKFT42c7gp4zaYcb/0TFAXrt9qw8yEz0wjvaug85+/WddlPTfT525Qei8iIUsF6t4bHYrsb2O7crg==",
         "dependencies": {
-          "Newtonsoft.Json": "13.0.3"
+          "Newtonsoft.Json": "13.0.4"
         }
       },
       "Google.LongRunning": {
         "type": "Transitive",
-        "resolved": "3.3.0",
-        "contentHash": "F2SZ83Jo466Wj/s1Z7QhIAmWBXxJZQyXZpcx0P8BR7d6s0FAj67vQjeUPESSJcvsy8AqYiYBhkUr2YpZhTQeHg==",
+        "resolved": "3.5.0",
+        "contentHash": "W8xO6FA+rG8WjKOsyIjTKjeKLcyCrjBBYeEdZ4QBkKQcxmRczbrfKhKQmdorb2V35CqXeeTbue5Na6Zkgyv8ow==",
         "dependencies": {
-          "Google.Api.Gax.Grpc": "[4.8.0, 5.0.0)"
+          "Google.Api.Gax.Grpc": "[4.12.1, 5.0.0)"
         }
       },
       "Google.Protobuf": {
         "type": "Transitive",
-        "resolved": "3.28.2",
-        "contentHash": "Z86ZKAB+v1B/m0LTM+EVamvZlYw/g3VND3/Gs4M/+aDIxa2JE9YPKjDxTpf0gv2sh26hrve3eI03brxBmzn92g=="
+        "resolved": "3.31.1",
+        "contentHash": "gSnJbUmGiOTdWddPhqzrEscHq9Ls6sqRDPB9WptckyjTUyx70JOOAaDLkFff8gManZNN3hllQ4aQInnQyq/Z/A=="
       },
       "Grpc.Auth": {
         "type": "Transitive",
-        "resolved": "2.66.0",
-        "contentHash": "FRQlhMAcHf0GjAXIfhN6RydfZncLLXNNTOtpLL1bt57kp59vu40faW+dr6Vwl7ef/IUFfF38aiB5jvhAA/9Aow==",
+        "resolved": "2.71.0",
+        "contentHash": "t2aGh/pMgqmc3GimtYfC7VcgVY/VSbk6SLH+61wewsgK45tzxxD9nYYItT5bpLn7fbebirmHXfgJcVKIArd0cg==",
         "dependencies": {
-          "Google.Apis.Auth": "1.68.0",
-          "Grpc.Core.Api": "2.66.0"
+          "Google.Apis.Auth": "1.69.0",
+          "Grpc.Core.Api": "2.71.0"
         }
       },
       "Grpc.Core.Api": {
         "type": "Transitive",
-        "resolved": "2.66.0",
-        "contentHash": "HsjsQVAHe4hqP4t4rpUnmq+MZvPdyrlPsWF4T5fbMvyP3o/lMV+KVJfDlaNH8+v0aGQTVT3EsDFufbhaWb52cw=="
+        "resolved": "2.71.0",
+        "contentHash": "QquqUC37yxsDzd1QaDRsH2+uuznWPTS8CVE2Yzwl3CvU4geTNkolQXoVN812M2IwT6zpv3jsZRc9ExJFNFslTg=="
       },
       "Grpc.Net.Client": {
         "type": "Transitive",
-        "resolved": "2.66.0",
-        "contentHash": "GwkSsssXFgN9+M2U+UQWdErf61sn1iqgP+2NRBlDXATcP9vlxda0wySxd/eIL8U522+SnyFNUXlvQ5tAzGk9cA==",
+        "resolved": "2.71.0",
+        "contentHash": "U1vr20r5ngoT9nlb7wejF28EKN+taMhJsV9XtK9MkiepTZwnKxxiarriiMfCHuDAfPUm9XUjFMn/RIuJ4YY61w==",
         "dependencies": {
-          "Grpc.Net.Common": "2.66.0",
+          "Grpc.Net.Common": "2.71.0",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.0"
         }
       },
       "Grpc.Net.Common": {
         "type": "Transitive",
-        "resolved": "2.66.0",
-        "contentHash": "YJpQpIvpo0HKlsG6SHwaieyji08qfv0DdEDIewCAA0egQY08637sHOj1netLGUhzBEsCqlGC3e92TZ2uqhxnvw==",
+        "resolved": "2.71.0",
+        "contentHash": "v0c8R97TwRYwNXlC8GyRXwYTCNufpDfUtj9la+wUrZFzVWkFJuNAltU+c0yI3zu0jl54k7en6u2WKgZgd57r2Q==",
         "dependencies": {
-          "Grpc.Core.Api": "2.66.0"
+          "Grpc.Core.Api": "2.71.0"
         }
       },
       "KokoroSharp": {
@@ -258,13 +267,16 @@
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "xlzi2IYREJH3/m6+lUrQlujzX8wDitm4QGnUu6kUXTQAWPuZY8i+ticFJbzfqaetLA6KR/rO6Ew/HuYD+bxifg=="
+        "resolved": "8.0.2",
+        "contentHash": "3iE7UF7MQkCv1cxzCahz+Y/guQbTqieyxyaWKhrRO91itI9cOKO76OHeQDahqG4MmW5umr3CcCvGmK92lWNlbg=="
       },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "/HggWBbTwy8TgebGSX5DBZ24ndhzi93sHUBDvP1IxbZD7FDokYzdAr6+vbWGjw2XAfR2EJ1sfKUotpjHnFWPxA=="
+        "resolved": "8.0.3",
+        "contentHash": "dL0QGToTxggRLMYY4ZYX5AMwBb+byQBd/5dMiZE07Nv73o6I5Are3C7eQTh7K2+A4ct0PVISSr7TZANbiNb2yQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2"
+        }
       },
       "Microsoft.ML.OnnxRuntime": {
         "type": "Transitive",
@@ -331,8 +343,8 @@
       },
       "Newtonsoft.Json": {
         "type": "Transitive",
-        "resolved": "13.0.3",
-        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+        "resolved": "13.0.4",
+        "contentHash": "pdgNNMai3zv51W5aq268sujXUyx7SNdE2bj1wZcWjAQrKMFZV260lbqYop1d2GM67JI1huLRwxo9ZqnfF/lC6A=="
       },
       "NumSharp": {
         "type": "Transitive",
@@ -358,6 +370,15 @@
         "resolved": "5.0.0-pre.13",
         "contentHash": "65qbZS49AfrTM6jtZ2RDTWAzLe13ywCXIiSP5QrAJLmZT6sQqHGd1LfFXLhx8Ccp77qy7qh/LHsxpUOlkgZTCg=="
       },
+      "System.ClientModel": {
+        "type": "Transitive",
+        "resolved": "1.8.1",
+        "contentHash": "4oUQgw/vaO4FBOk3YsH40hbrjxRED1l95rRLvTMtHXfQxapXya9IfPpm/KgwValFFtYTfYGFOs/qzGmGyexicQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
+          "System.Memory.Data": "8.0.1"
+        }
+      },
       "System.CodeDom": {
         "type": "Transitive",
         "resolved": "7.0.0",
@@ -370,6 +391,11 @@
         "dependencies": {
           "System.CodeDom": "7.0.0"
         }
+      },
+      "System.Memory.Data": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "BVYuec3jV23EMRDeR7Dr1/qhx7369dZzJ9IWy2xylvb4YfXsrUxspWc4UWYid/tj4zZK58uGZqn2WQiaDMhmAg=="
       },
       "System.Numerics.Tensors": {
         "type": "Transitive",

--- a/src/TextToTalk/packages.lock.json
+++ b/src/TextToTalk/packages.lock.json
@@ -86,6 +86,18 @@
           "System.ClientModel": "1.8.1"
         }
       },
+      "PiperSharp": {
+        "type": "Direct",
+        "requested": "[1.0.6, )",
+        "resolved": "1.0.6",
+        "contentHash": "g68TbampKc0ATx80nur6LHHrhIpXvmioIVuwAuWKcjTXTB2tf+Klk4JPwzWZRo+DRSR4kS370eh+davEQVR0cw==",
+        "dependencies": {
+          "NAudio": "2.2.1",
+          "NAudio.Core": "2.2.1",
+          "Newtonsoft.Json": "13.0.1",
+          "SharpCompress": "0.36.0"
+        }
+      },
       "R3": {
         "type": "Direct",
         "requested": "[1.2.9, )",
@@ -370,6 +382,14 @@
         "resolved": "5.0.0-pre.13",
         "contentHash": "65qbZS49AfrTM6jtZ2RDTWAzLe13ywCXIiSP5QrAJLmZT6sQqHGd1LfFXLhx8Ccp77qy7qh/LHsxpUOlkgZTCg=="
       },
+      "SharpCompress": {
+        "type": "Transitive",
+        "resolved": "0.36.0",
+        "contentHash": "48am//T6Ou+GmyPmBaxaFN1ym0VNidRcBeANr9+OYTzpKRz8QMGzAkHVkCV30lFQ/gnWqGr50AuebahpG1C6xA==",
+        "dependencies": {
+          "ZstdSharp.Port": "0.7.4"
+        }
+      },
       "System.ClientModel": {
         "type": "Transitive",
         "resolved": "1.8.1",
@@ -406,6 +426,11 @@
         "type": "Transitive",
         "resolved": "15.3.0",
         "contentHash": "F93japYa9YrJ59AZGhgdaUGHN7ITJ55FBBg/D/8C0BDgahv/rQD6MOSwHxOJJpon1kYyslVbeBrQ2wcJhox01w=="
+      },
+      "ZstdSharp.Port": {
+        "type": "Transitive",
+        "resolved": "0.7.4",
+        "contentHash": "ziptnotpUJr51afwXJQ5Wc03dvDiZAdmxS08s1g7SHn/VzbyZUXdH6yORk/zaNjzUOEE6pVZ0Nqztab0rYROgQ=="
       },
       "texttotalk.data": {
         "type": "Project",


### PR DESCRIPTION
Extensive rework of SoundQueues to utilize streaming to a buffer.  This allows playback while synthesis is still in progress.  For some backends this has significantly reduced latency.

Made changes for Uberduck backend to support their versioned API and leveraging of API Keys.

Added Piper Backend.  User has full control over downloaded voices and can monitor size of voice directory in the ConfigWindow.

Added Latency Tracker (accessible via ConfigWindow or ``/tttstats`` command.  This shows latency for all TTS requests during session. Stats can be manually cleared for testing.  This is to give the user an idea of how long it takes for time to first audio.