### PR TITLE
feat(addon): Add option to automatically advance dialogue when TTS finishes

### DIFF
--- a/src/TextToTalk/Backends/Azure/AzureClient.cs
+++ b/src/TextToTalk/Backends/Azure/AzureClient.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -93,7 +93,7 @@ public class AzureClient : IDisposable
             var soundStream = new MemoryStream(res.AudioData);
             soundStream.Seek(0, SeekOrigin.Begin);
 
-            this.soundQueue.EnqueueSound(soundStream, source, StreamFormat.Wave, volume);
+            this.soundQueue.EnqueueSound(soundStream, source, StreamFormat.Wave, volume, text);
         }
         finally
         {

--- a/src/TextToTalk/Backends/ElevenLabs/ElevenLabsClient.cs
+++ b/src/TextToTalk/Backends/ElevenLabs/ElevenLabsClient.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
@@ -78,7 +78,7 @@ public class ElevenLabsClient
         await responseStream.CopyToAsync(mp3Stream);
         mp3Stream.Seek(0, SeekOrigin.Begin);
 
-        this.soundQueue.EnqueueSound(mp3Stream, source, StreamFormat.Mp3, volume);
+        this.soundQueue.EnqueueSound(mp3Stream, source, StreamFormat.Mp3, volume, text);
     }
 
     public async Task<ElevenLabsUserSubscriptionInfo> GetUserSubscriptionInfo()

--- a/src/TextToTalk/Backends/GoogleCloud/GoogleCloudClient.cs
+++ b/src/TextToTalk/Backends/GoogleCloud/GoogleCloudClient.cs
@@ -96,6 +96,6 @@ public class GoogleCloudClient
         MemoryStream mp3Stream = new MemoryStream(response.AudioContent.ToByteArray());
         mp3Stream.Seek(0, SeekOrigin.Begin);
 
-        soundQueue.EnqueueSound(mp3Stream, source, StreamFormat.Mp3, volume);
+        soundQueue.EnqueueSound(mp3Stream, source, StreamFormat.Mp3, volume, text);
     }
 }

--- a/src/TextToTalk/Backends/Kokoro/KokoroSoundQueue.cs
+++ b/src/TextToTalk/Backends/Kokoro/KokoroSoundQueue.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Threading.Tasks;
 using Dalamud.Game;
@@ -104,7 +104,7 @@ public class KokoroSoundQueue : SoundQueue<KokoroSourceQueueItem>
 
             var bytes = KokoroPlayback.GetBytes(samples);
             var ms = new MemoryStream(bytes);
-            streamSoundQueue.EnqueueSound(ms, nextItem.Source, StreamFormat.Raw, nextItem.Volume);
+            streamSoundQueue.EnqueueSound(ms, nextItem.Source, StreamFormat.Raw, nextItem.Volume, nextItem.Text);
         }
     }
 }

--- a/src/TextToTalk/Backends/OpenAI/OpenAiClient.cs
+++ b/src/TextToTalk/Backends/OpenAI/OpenAiClient.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -226,7 +226,7 @@ public class OpenAiClient(StreamSoundQueue soundQueue, HttpClient http)
         await responseStream.CopyToAsync(mp3Stream);
         mp3Stream.Seek(0, SeekOrigin.Begin);
 
-        soundQueue.EnqueueSound(mp3Stream, request.Source, StreamFormat.Mp3, preset.Volume);
+        soundQueue.EnqueueSound(mp3Stream, request.Source, StreamFormat.Mp3, preset.Volume, request.Text);
     }
 
     private static async Task EnsureSuccessStatusCode(HttpResponseMessage res)

--- a/src/TextToTalk/Backends/Polly/PollyClient.cs
+++ b/src/TextToTalk/Backends/Polly/PollyClient.cs
@@ -1,4 +1,4 @@
-﻿using Amazon;
+using Amazon;
 using Amazon.Polly;
 using Amazon.Polly.Model;
 using Amazon.Runtime;
@@ -86,7 +86,7 @@ namespace TextToTalk.Backends.Polly
             await res.AudioStream.CopyToAsync(responseStream);
             responseStream.Seek(0, SeekOrigin.Begin);
 
-            this.soundQueue.EnqueueSound(responseStream, source, StreamFormat.Mp3, volume);
+            this.soundQueue.EnqueueSound(responseStream, source, StreamFormat.Mp3, volume, text);
         }
 
         public Task CancelAllSounds()

--- a/src/TextToTalk/Backends/SoundQueueItem.cs
+++ b/src/TextToTalk/Backends/SoundQueueItem.cs
@@ -1,10 +1,11 @@
-﻿using System;
+using System;
 
 namespace TextToTalk.Backends
 {
     public class SoundQueueItem : IDisposable
     {
         public TextSource Source { get; init; }
+        public string? Text { get; init; }
 
         protected virtual void Dispose(bool disposing) { }
 

--- a/src/TextToTalk/Backends/SpeechFinishedNotifier.cs
+++ b/src/TextToTalk/Backends/SpeechFinishedNotifier.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace TextToTalk.Backends
+{
+    public static class SpeechFinishedNotifier
+    {
+        public static event Action<TextSource, string?>? SpeechFinished;
+
+        public static void Trigger(TextSource source, string? text)
+        {
+            SpeechFinished?.Invoke(source, text);
+        }
+    }
+}

--- a/src/TextToTalk/Backends/StreamSoundQueue.cs
+++ b/src/TextToTalk/Backends/StreamSoundQueue.cs
@@ -1,4 +1,4 @@
-﻿using NAudio.Wave;
+using NAudio.Wave;
 using NAudio.Wave.SampleProviders;
 using System;
 using System.IO;
@@ -13,6 +13,7 @@ namespace TextToTalk.Backends
         private readonly AutoResetEvent speechCompleted = new(false);
         private readonly object soundLock = true;
         private DirectSoundOut? soundOut;
+        private volatile bool cancelled;
 
         protected override void OnSoundLoop(StreamSoundQueueItem nextItem)
         {
@@ -33,6 +34,8 @@ namespace TextToTalk.Backends
             var volumeSampleProvider = new VolumeSampleProvider(sampleProvider) { Volume = effectiveVolume };
             var playbackDeviceId = config.SelectedAudioDeviceGuid;
 
+            this.cancelled = false;
+
             // Play the sound
             lock (this.soundLock)
             {
@@ -47,8 +50,13 @@ namespace TextToTalk.Backends
             // Cleanup
             lock (this.soundLock)
             {
-                this.soundOut.Dispose();
+                this.soundOut?.Dispose();
                 this.soundOut = null;
+            }
+
+            if (!this.cancelled)
+            {
+                SpeechFinishedNotifier.Trigger(nextItem.Source, nextItem.Text);
             }
         }
 
@@ -57,7 +65,7 @@ namespace TextToTalk.Backends
             StopWaveOut();
         }
 
-        public void EnqueueSound(MemoryStream data, TextSource source, StreamFormat format, float volume)
+        public void EnqueueSound(MemoryStream data, TextSource source, StreamFormat format, float volume, string? text = null)
         {
             AddQueueItem(new StreamSoundQueueItem
             {
@@ -65,6 +73,7 @@ namespace TextToTalk.Backends
                 Volume = volume,
                 Source = source,
                 Format = format,
+                Text = text,
             });
         }
 
@@ -74,6 +83,7 @@ namespace TextToTalk.Backends
             {
                 lock (this.soundLock)
                 {
+                    this.cancelled = true;
                     this.soundOut?.Stop();
                 }
             }

--- a/src/TextToTalk/Backends/System/SystemSoundQueue.cs
+++ b/src/TextToTalk/Backends/System/SystemSoundQueue.cs
@@ -1,4 +1,4 @@
-﻿using R3;
+using R3;
 using System;
 using System.IO;
 using System.Threading;
@@ -108,7 +108,7 @@ namespace TextToTalk.Backends.System
             {
                 this.consecutiveFailures = 0;
                 synthesisStream.Seek(0, SeekOrigin.Begin);
-                this.streamSoundQueue.EnqueueSound(synthesisStream, nextItem.Source, StreamFormat.Wave, 1f);
+                this.streamSoundQueue.EnqueueSound(synthesisStream, nextItem.Source, StreamFormat.Wave, 1f, nextItem.Text);
             }
         }
 

--- a/src/TextToTalk/Backends/Uberduck/UberduckClient.cs
+++ b/src/TextToTalk/Backends/Uberduck/UberduckClient.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -103,7 +103,7 @@ public partial class UberduckClient
         await responseStream.CopyToAsync(waveStream);
         waveStream.Seek(0, SeekOrigin.Begin);
 
-        this.soundQueue.EnqueueSound(waveStream, source, StreamFormat.Wave, volume);
+        this.soundQueue.EnqueueSound(waveStream, source, StreamFormat.Wave, volume, text);
     }
 
     private Task<UberduckSpeechStatusResponse?> GetSpeechStatus(string uuid)

--- a/src/TextToTalk/PluginConfiguration.cs
+++ b/src/TextToTalk/PluginConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using Amazon.Polly;
+using Amazon.Polly;
 using Dalamud.Configuration;
 using Dalamud.Game.Text;
 using Dalamud.Plugin;
@@ -160,6 +160,7 @@ namespace TextToTalk
         public bool ReadFromQuestTalkAddon { get; set; } = true;
         public bool CancelSpeechOnTextAdvance { get; set; }
         public bool SkipVoicedQuestText { get; set; } = true;
+        public bool AutoAdvanceDialogue { get; set; }
 
         public bool ReadFromBattleTalkAddon { get; set; } = true;
         public bool SkipVoicedBattleText { get; set; } = true;

--- a/src/TextToTalk/Talk/AddonTalkManager.cs
+++ b/src/TextToTalk/Talk/AddonTalkManager.cs
@@ -1,4 +1,4 @@
-﻿using Dalamud.Plugin.Services;
+using Dalamud.Plugin.Services;
 using FFXIVClientStructs.FFXIV.Client.UI;
 using TextToTalk.Utils;
 
@@ -21,6 +21,31 @@ public class AddonTalkManager : AddonManager
     {
         var addonTalk = GetAddonTalk();
         return addonTalk != null && addonTalk->AtkUnitBase.IsVisible;
+    }
+
+    public unsafe void Advance()
+    {
+        var addonTalk = GetAddonTalk();
+        if (addonTalk == null || !addonTalk->AtkUnitBase.IsVisible) return;
+
+        var stage = FFXIVClientStructs.FFXIV.Component.GUI.AtkStage.Instance();
+        if (stage == null) return;
+
+        var target = &stage->AtkEventTarget;
+
+        var evt = new FFXIVClientStructs.FFXIV.Component.GUI.AtkEvent
+        {
+            Target = target,
+            Listener = (FFXIVClientStructs.FFXIV.Component.GUI.AtkEventListener*)addonTalk,
+        };
+        evt.State.StateFlags = (FFXIVClientStructs.FFXIV.Component.GUI.AtkEventStateFlags)132;
+
+        var data = new FFXIVClientStructs.FFXIV.Component.GUI.AtkEventData();
+
+        var listener = (FFXIVClientStructs.FFXIV.Component.GUI.AtkEventListener*)addonTalk;
+        listener->ReceiveEvent(FFXIVClientStructs.FFXIV.Component.GUI.AtkEventType.MouseDown, 0, &evt, &data);
+        listener->ReceiveEvent(FFXIVClientStructs.FFXIV.Component.GUI.AtkEventType.MouseClick, 0, &evt, &data);
+        listener->ReceiveEvent(FFXIVClientStructs.FFXIV.Component.GUI.AtkEventType.MouseUp, 0, &evt, &data);
     }
 
     private unsafe AddonTalk* GetAddonTalk()

--- a/src/TextToTalk/TextToTalk.cs
+++ b/src/TextToTalk/TextToTalk.cs
@@ -1,4 +1,4 @@
-﻿using Dalamud.Game.ClientState.Objects.SubKinds;
+using Dalamud.Game.ClientState.Objects.SubKinds;
 using Dalamud.Game.Text;
 using Dalamud.Game.Text.SeStringHandling;
 using Dalamud.Interface.Windowing;
@@ -547,10 +547,14 @@ namespace TextToTalk
 
             this.framework.Update += this.notificationService.ProcessNotifications;
             this.framework.Update += CheckKeybindPressed;
+
+            SpeechFinishedNotifier.SpeechFinished += OnSpeechFinished;
         }
 
         private void UnregisterCallbacks()
         {
+            SpeechFinishedNotifier.SpeechFinished -= OnSpeechFinished;
+
             this.framework.Update -= CheckKeybindPressed;
             this.framework.Update -= this.notificationService.ProcessNotifications;
 
@@ -558,6 +562,48 @@ namespace TextToTalk
             this.pluginInterface.UiBuilder.OpenMainUi -= this.configurationWindow.Open;
 
             this.pluginInterface.UiBuilder.Draw -= this.windows.Draw;
+        }
+
+        private void OnSpeechFinished(TextSource source, string? spokenText)
+        {
+            if (source == TextSource.AddonTalk && this.config.Enabled && this.config.AutoAdvanceDialogue)
+            {
+                _ = this.framework.RunOnFrameworkThread(() =>
+                {
+                    if (this.addonTalkManager.IsVisible())
+                    {
+                        var currentTalkText = this.addonTalkManager.ReadText()?.Text;
+                        if (IsDialogueTextMatching(currentTalkText, spokenText))
+                        {
+                            DetailedLog.Debug("TTS finished reading dialogue. Automatically advancing dialogue.");
+                            this.addonTalkManager.Advance();
+                        }
+                        else
+                        {
+                            DetailedLog.Debug("TTS finished reading, but dialogue text has already changed or closed. Skipping auto-advance.");
+                        }
+                    }
+                });
+            }
+        }
+
+        private bool IsDialogueTextMatching(string? text1, string? text2)
+        {
+            if (text1 == null || text2 == null) return false;
+            return NormalizeForComparison(text1) == NormalizeForComparison(text2);
+        }
+
+        private string NormalizeForComparison(string text)
+        {
+            var sb = new System.Text.StringBuilder();
+            foreach (var c in text)
+            {
+                if (char.IsLetterOrDigit(c))
+                {
+                    sb.Append(char.ToLowerInvariant(c));
+                }
+            }
+            return sb.ToString();
         }
 
         #region IDisposable Support

--- a/src/TextToTalk/UI/ConfigurationWindow.cs
+++ b/src/TextToTalk/UI/ConfigurationWindow.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
@@ -193,6 +193,9 @@ namespace TextToTalk.UI
                         this.config);
                     ConfigComponents.ToggleSkipVoicedQuestText(
                         "Skip reading voice-acted NPC dialogue",
+                        this.config);
+                    ConfigComponents.ToggleAutoAdvanceDialogue(
+                        "Automatically advance dialogue when speech finishes",
                         this.config);
 
                     ImGui.Unindent();


### PR DESCRIPTION
- Adds AutoAdvanceDialogue configuration property and UI toggle.
- Implements SpeechFinishedNotifier to broadcast TTS playback finished events.
- Enqueues spoken text with audio queue items to check against the game's active dialogue text.
- Normalizes and compares text before advancing to prevent double-advancing or out-of-sync triggers.
- Simulates a native mouse click on the Talk addon using AtkEventListener.ReceiveEvent (MouseDown, MouseClick, MouseUp) to prevent player lockout/UI hangs on dialogue end.