### PR TITLE
Added effective voice volume to IPC message

### DIFF
--- a/src/TextToTalk.Tests/Backends/Websocket/WSServerTests.cs
+++ b/src/TextToTalk.Tests/Backends/Websocket/WSServerTests.cs
@@ -131,6 +131,55 @@ public class WSServerTests
         await Assert.ThrowsAsync<ArgumentException>(() => RunStandardBroadcastTest(IPAddress.IPv6Any, TextSource.Chat));
     }
 
+    [Fact]
+    public async Task Broadcast_SendsVolumeInMessage()
+    {
+        // Set up the server
+        var configProvider = Mock.Of<IWebsocketConfigProvider>();
+        using var server = new WSServer(configProvider, 0);
+        server.Start();
+
+        // Set up the client
+        using var client = CreateClient(server);
+
+        // Filter for say messages only
+        using var list = OnIpcMessage(client)
+            .Where(m => m?.Type == IpcMessageType.Say.ToString())
+            .Select(m => m!)
+            .Take(1)
+            .ToLiveList();
+
+        // Send the message with a specific volume
+        var preset = new VoicePreset
+        {
+            Id = 0,
+            EnabledBackend = TTSBackend.Websocket,
+            Name = "Some Body",
+        };
+
+        server.Broadcast(new SayRequest
+        {
+            Source = TextSource.Chat,
+            Voice = preset,
+            Speaker = "Speaker",
+            Text = "Hello, world!",
+            TextTemplate = "Hello, world!",
+            Race = "Hyur",
+            BodyType = GameEnums.BodyType.Adult,
+            Gender = GameEnums.Gender.None,
+            ChatType = XivChatType.Say,
+            Language = ClientLanguage.English,
+            Volume = 0.75f,
+        });
+
+        // Wait a bit
+        await Task.Delay(100);
+
+        // Assert that the volume was included in the message
+        Assert.True(list.IsCompleted);
+        Assert.Equal(0.75f, list[0].Volume);
+    }
+
     private static async Task RunStandardBroadcastTest(IPAddress? address, TextSource source)
     {
         // Set up the server

--- a/src/TextToTalk.Tests/Utils/SoundSettingsUtilsTests.cs
+++ b/src/TextToTalk.Tests/Utils/SoundSettingsUtilsTests.cs
@@ -1,0 +1,67 @@
+using Dalamud.Game.Config;
+using Dalamud.Plugin.Services;
+using Moq;
+using TextToTalk.Utils;
+using Xunit;
+
+namespace TextToTalk.Tests.Utils;
+
+public class SoundSettingsUtilsTests
+{
+    [Theory]
+    [InlineData(100, 100, false, false, 1.0f)]
+    [InlineData(50, 100, false, false, 0.5f)]
+    [InlineData(100, 50, false, false, 0.5f)]
+    [InlineData(50, 50, false, false, 0.25f)]
+    [InlineData(0, 100, false, false, 0.0f)]
+    [InlineData(100, 0, false, false, 0.0f)]
+    [InlineData(100, 100, true, false, 0.0f)]
+    [InlineData(100, 100, false, true, 0.0f)]
+    [InlineData(100, 100, true, true, 0.0f)]
+    [InlineData(0, 0, true, true, 0.0f)]
+    public void GetEffectiveVolume_ComputesCorrectValue(
+        uint masterVolume, uint voiceVolume, bool masterMuted, bool voiceMuted, float expected)
+    {
+        var gameConfig = MockGameConfig(masterVolume, voiceVolume, masterMuted, voiceMuted);
+
+        var result = SoundSettingsUtils.GetEffectiveVoiceVolume(gameConfig.Object);
+
+        Assert.Equal(expected, result);
+    }
+
+    private static Mock<IGameConfig> MockGameConfig(
+        uint masterVolume, uint voiceVolume, bool masterMuted, bool voiceMuted)
+    {
+        var gameConfig = new Mock<IGameConfig>();
+
+        gameConfig.Setup(gc => gc.TryGet(SystemConfigOption.SoundMaster, out It.Ref<uint>.IsAny))
+            .Returns((SystemConfigOption _, out uint val) =>
+            {
+                val = masterVolume;
+                return true;
+            });
+
+        gameConfig.Setup(gc => gc.TryGet(SystemConfigOption.SoundVoice, out It.Ref<uint>.IsAny))
+            .Returns((SystemConfigOption _, out uint val) =>
+            {
+                val = voiceVolume;
+                return true;
+            });
+
+        gameConfig.Setup(gc => gc.TryGet(SystemConfigOption.IsSndMaster, out It.Ref<bool>.IsAny))
+            .Returns((SystemConfigOption _, out bool val) =>
+            {
+                val = masterMuted;
+                return true;
+            });
+
+        gameConfig.Setup(gc => gc.TryGet(SystemConfigOption.IsSndVoice, out It.Ref<bool>.IsAny))
+            .Returns((SystemConfigOption _, out bool val) =>
+            {
+                val = voiceMuted;
+                return true;
+            });
+
+        return gameConfig;
+    }
+}

--- a/src/TextToTalk/Backends/SayRequest.cs
+++ b/src/TextToTalk/Backends/SayRequest.cs
@@ -82,6 +82,11 @@ public record SayRequest
     public required ClientLanguage Language { get; init; }
 
     /// <summary>
+    /// The current game sound level (master * voice, 0-1), to be included in IPC messages.
+    /// </summary>
+    public float Volume { get; init; }
+
+    /// <summary>
     /// The intended IPC message type for this object, only to be used for object mapping.
     /// </summary>
     public IpcMessageType MessageType => IpcMessageType.Say;

--- a/src/TextToTalk/Backends/Websocket/IpcMessage.cs
+++ b/src/TextToTalk/Backends/Websocket/IpcMessage.cs
@@ -81,13 +81,18 @@ public class IpcMessage(IpcMessageType type, TextSource source) : IEquatable<Ipc
     /// </summary>
     public string? Language { get; init; }
 
+    /// <summary>
+    /// The current game sound level (master * voice, 0-1). 0 when muted.
+    /// </summary>
+    public float Volume { get; init; }
+
     public bool Equals(IpcMessage? other)
     {
         if (ReferenceEquals(null, other)) return false;
         if (ReferenceEquals(this, other)) return true;
         return Speaker == other.Speaker && Type == other.Type && Payload == other.Payload &&
                Equals(Voice, other.Voice) && StuttersRemoved == other.StuttersRemoved && Source == other.Source &&
-               NpcId == other.NpcId && ChatType == other.ChatType;
+               NpcId == other.NpcId && ChatType == other.ChatType && Volume.Equals(other.Volume);
     }
 
     public override bool Equals(object? obj)
@@ -99,6 +104,8 @@ public class IpcMessage(IpcMessageType type, TextSource source) : IEquatable<Ipc
 
     public override int GetHashCode()
     {
-        return HashCode.Combine(Speaker, Type, Payload, Voice, StuttersRemoved, Source, NpcId, ChatType);
+        return HashCode.Combine(
+            HashCode.Combine(Speaker, Type, Payload, Voice, StuttersRemoved, Source, NpcId, ChatType),
+            Volume);
     }
 }

--- a/src/TextToTalk/TextToTalk.cs
+++ b/src/TextToTalk/TextToTalk.cs
@@ -54,7 +54,7 @@ namespace TextToTalk
         private const bool InitiallyVisible = false;
 #endif
 
-        private readonly IDalamudPluginInterface pluginInterface;
+private readonly IDalamudPluginInterface pluginInterface;
         private readonly MainCommandModule commandModule;
         private readonly DebugCommandModule debugCommandModule;
         private readonly IKeyState keys;
@@ -62,6 +62,7 @@ namespace TextToTalk
         private readonly IFramework framework;
         private readonly IClientState clientState;
         private readonly IObjectTable objects;
+        private readonly IGameConfig gameConfig;
 
         private readonly PluginConfiguration config;
         private readonly AddonTalkManager addonTalkManager;
@@ -108,7 +109,8 @@ namespace TextToTalk
             ISigScanner sigScanner,
             IGameInteropProvider gameInterop,
             INotificationManager notificationManager,
-            IPluginLog pluginLog)
+            IPluginLog pluginLog,
+            IGameConfig gameConfig)
         {
             DetailedLog.SetLogger(pluginLog);
 
@@ -119,6 +121,7 @@ namespace TextToTalk
             this.chat = chat;
             this.framework = framework;
             this.data = data;
+            this.gameConfig = gameConfig;
 
             CreateDatabasePath();
             CreateEventLogDatabase();
@@ -386,7 +389,7 @@ namespace TextToTalk
                 return;
             }
 
-            // Say the thing
+// Say the thing
             BackendSay(new SayRequest
             {
                 Source = source,
@@ -402,6 +405,7 @@ namespace TextToTalk
                 BodyType = bodyType,
                 Gender = gender,
                 StuttersRemoved = this.config.RemoveStutterEnabled,
+                Volume = SoundSettingsUtils.GetEffectiveVoiceVolume(this.gameConfig),
             });
         }
 

--- a/src/TextToTalk/Utils/SoundSettingsUtils.cs
+++ b/src/TextToTalk/Utils/SoundSettingsUtils.cs
@@ -1,0 +1,20 @@
+using Dalamud.Game.Config;
+using Dalamud.Plugin.Services;
+
+namespace TextToTalk.Utils;
+
+public static class SoundSettingsUtils
+{
+    public static float GetEffectiveVoiceVolume(IGameConfig gameConfig)
+    {
+        gameConfig.TryGet(SystemConfigOption.SoundMaster, out uint masterVolume);
+        gameConfig.TryGet(SystemConfigOption.SoundVoice, out uint voiceVolume);
+        gameConfig.TryGet(SystemConfigOption.IsSndMaster, out bool masterMuted);
+        gameConfig.TryGet(SystemConfigOption.IsSndVoice, out bool voiceMuted);
+
+        if (masterMuted || voiceMuted || masterVolume == 0 || voiceVolume == 0)
+            return 0f;
+
+        return (masterVolume / 100f) * (voiceVolume / 100f);
+    }
+}


### PR DESCRIPTION
Websocket clients consuming TTS from TextToTalk had no way to tie their volume to the game's in‑game Master/Voice volume sliders, forcing them to manage volume independently.

Changes:
- Added SoundSettingsUtils.GetEffectiveVoiceVolume(). Reads FFXIV's Master volume, Voice volume, and their mute states via IGameConfig, returns master * voice as a 0–1 float (or 0 when muted)
- Added Volume field to SayRequest and IpcMessage, populated at send time
- The volume is now included in every Say websocket message, so clients can adjust their output volume to match the player's current sound settings

I'm unsure if hashcode and equality care about this new field. probably not? 🤔