### PR TITLE
Added dialogue start  / stop approximation events

### DIFF
--- a/src/TextToTalk.Tests/Services/DialogueSessionServiceTests.cs
+++ b/src/TextToTalk.Tests/Services/DialogueSessionServiceTests.cs
@@ -1,0 +1,604 @@
+using Dalamud.Game.ClientState.Conditions;
+using Dalamud.Plugin.Services;
+using Moq;
+using R3;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using TextToTalk.Backends.Websocket;
+using TextToTalk.Events;
+using TextToTalk.Services;
+using TextToTalk.Talk;
+using Xunit;
+
+namespace TextToTalk.Tests.Services;
+
+public class DialogueSessionServiceTests
+{
+    private readonly Mock<IFramework> framework;
+    private readonly Mock<IClientState> clientState;
+    private readonly Mock<ICondition> condition;
+    private readonly Mock<IAddonTalkManager> talk;
+    private readonly Mock<IAddonBattleTalkManager> battleTalk;
+    private readonly Mock<IAddonSelectStringManager> selectString;
+    private readonly Mock<IAddonSelectIconStringManager> selectIcon;
+
+    public DialogueSessionServiceTests()
+    {
+        framework = new Mock<IFramework>();
+        clientState = new Mock<IClientState>();
+        condition = new Mock<ICondition>();
+        talk = new Mock<IAddonTalkManager>();
+        battleTalk = new Mock<IAddonBattleTalkManager>();
+        selectString = new Mock<IAddonSelectStringManager>();
+        selectIcon = new Mock<IAddonSelectIconStringManager>();
+
+        framework.Setup(f => f.Run(It.IsAny<Action>(), It.IsAny<CancellationToken>()))
+            .Callback<Action, CancellationToken>((action, _) => action());
+    }
+
+    private DialogueSessionService CreateService() => new(
+        framework.Object, clientState.Object, condition.Object,
+        selectString.Object, selectIcon.Object,
+        talk.Object, battleTalk.Object);
+
+    private void AdvanceFrame() =>
+        framework.Raise(f => f.Update += null, framework.Object);
+
+    // ---------------------------------------------------------------
+    // Session start
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void NpcText_StartsSession()
+    {
+        using var service = CreateService();
+        using var events = service.OnEvent.ToLiveList();
+
+        service.NotifyDialogue(TextSource.AddonTalk);
+
+        Assert.Single(events);
+        var started = Assert.IsType<NpcDialogueSessionStartedEvent>(events[0]);
+        Assert.Equal(TextSource.AddonTalk, started.Source);
+        Assert.Equal(DialogueEventReason.TextReceived, started.Reason);
+    }
+
+    [Fact]
+    public void BattleDialogue_StartsSession()
+    {
+        using var service = CreateService();
+        using var events = service.OnEvent.ToLiveList();
+
+        service.NotifyDialogue(TextSource.AddonBattleTalk);
+
+        Assert.Single(events);
+        var started = Assert.IsType<NpcDialogueSessionStartedEvent>(events[0]);
+        Assert.Equal(TextSource.AddonBattleTalk, started.Source);
+        Assert.Equal(DialogueEventReason.TextReceived, started.Reason);
+    }
+
+    [Fact]
+    public void DialogueAddonVisibility_StartsSession()
+    {
+        using var service = CreateService();
+        using var events = service.OnEvent.ToLiveList();
+
+        talk.Setup(x => x.IsVisible()).Returns(true);
+        AdvanceFrame();
+
+        Assert.Single(events);
+        var started = Assert.IsType<NpcDialogueSessionStartedEvent>(events[0]);
+        Assert.Equal(TextSource.AddonTalk, started.Source);
+        Assert.Equal(DialogueEventReason.AddonShown, started.Reason);
+    }
+
+    [Fact]
+    public void BattleTalkAddonVisibility_StartsSession()
+    {
+        using var service = CreateService();
+        using var events = service.OnEvent.ToLiveList();
+
+        battleTalk.Setup(x => x.IsVisible()).Returns(true);
+        AdvanceFrame();
+
+        Assert.Single(events);
+        var started = Assert.IsType<NpcDialogueSessionStartedEvent>(events[0]);
+        Assert.Equal(TextSource.AddonBattleTalk, started.Source);
+        Assert.Equal(DialogueEventReason.AddonShown, started.Reason);
+    }
+
+    [Fact]
+    public void Chat_DoesNotStartSession()
+    {
+        using var service = CreateService();
+        using var events = service.OnEvent.ToLiveList();
+
+        service.NotifyDialogue(TextSource.Chat);
+
+        Assert.Empty(events);
+
+        // Even after frames, no session starts
+        AdvanceFrame();
+        AdvanceFrame();
+        AdvanceFrame();
+
+        Assert.Empty(events);
+    }
+
+    [Fact]
+    public void NoneSource_DoesNotStartSession()
+    {
+        using var service = CreateService();
+        using var events = service.OnEvent.ToLiveList();
+
+        service.NotifyDialogue(TextSource.None);
+
+        Assert.Empty(events);
+    }
+
+    // ---------------------------------------------------------------
+    // Duplicate suppression
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void AdditionalDialogue_DoesNotRestartSession()
+    {
+        using var service = CreateService();
+        using var events = service.OnEvent.ToLiveList();
+
+        service.NotifyDialogue(TextSource.AddonTalk);
+        service.NotifyDialogue(TextSource.AddonBattleTalk);
+
+        Assert.Single(events);
+    }
+
+    [Fact]
+    public void RepeatedAddonVisibility_DoesNotRestartSession()
+    {
+        using var service = CreateService();
+        using var events = service.OnEvent.ToLiveList();
+
+        talk.Setup(x => x.IsVisible()).Returns(true);
+        AdvanceFrame();
+        AdvanceFrame();
+        AdvanceFrame();
+
+        Assert.Single(events);
+    }
+
+    [Fact]
+    public void BothAddonsVisible_StartsOnce()
+    {
+        using var service = CreateService();
+        using var events = service.OnEvent.ToLiveList();
+
+        talk.Setup(x => x.IsVisible()).Returns(true);
+        battleTalk.Setup(x => x.IsVisible()).Returns(true);
+        AdvanceFrame();
+
+        Assert.Single(events);
+    }
+
+    // ---------------------------------------------------------------
+    // Session continuation
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void VisibleTalk_KeepsSessionAlive()
+    {
+        using var service = CreateService();
+        using var events = service.OnEvent.ToLiveList();
+
+        service.NotifyDialogue(TextSource.AddonTalk);
+        talk.Setup(x => x.IsVisible()).Returns(true);
+
+        for (var i = 0; i < 10; i++)
+            AdvanceFrame();
+
+        Assert.Single(events);
+    }
+
+    [Fact]
+    public void VisibleBattleTalk_KeepsSessionAlive()
+    {
+        using var service = CreateService();
+        using var events = service.OnEvent.ToLiveList();
+
+        service.NotifyDialogue(TextSource.AddonTalk);
+        battleTalk.Setup(x => x.IsVisible()).Returns(true);
+
+        for (var i = 0; i < 10; i++)
+            AdvanceFrame();
+
+        Assert.Single(events);
+    }
+
+    [Fact]
+    public void SelectionString_BridgesDialogueScreens()
+    {
+        using var service = CreateService();
+        using var events = service.OnEvent.ToLiveList();
+
+        service.NotifyDialogue(TextSource.AddonTalk);
+
+        // Talk closes, SelectString opens
+        talk.Setup(x => x.IsVisible()).Returns(false);
+        selectString.Setup(x => x.IsVisible()).Returns(true);
+
+        for (var i = 0; i < 10; i++)
+            AdvanceFrame();
+
+        Assert.Single(events);
+    }
+
+    [Fact]
+    public void SelectionIconString_BridgesDialogueScreens()
+    {
+        using var service = CreateService();
+        using var events = service.OnEvent.ToLiveList();
+
+        service.NotifyDialogue(TextSource.AddonTalk);
+
+        talk.Setup(x => x.IsVisible()).Returns(false);
+        selectIcon.Setup(x => x.IsVisible()).Returns(true);
+
+        for (var i = 0; i < 10; i++)
+            AdvanceFrame();
+
+        Assert.Single(events);
+    }
+
+    [Fact]
+    public void CutsceneCondition_BridgesLongPause()
+    {
+        using var service = CreateService();
+        using var events = service.OnEvent.ToLiveList();
+
+        service.NotifyDialogue(TextSource.AddonTalk);
+
+        talk.Setup(x => x.IsVisible()).Returns(false);
+        condition.Setup(c => c[ConditionFlag.WatchingCutscene]).Returns(true);
+
+        for (var i = 0; i < 100; i++)
+            AdvanceFrame();
+
+        Assert.Single(events);
+    }
+
+    [Fact]
+    public void Cutscene78Condition_BridgesLongPause()
+    {
+        using var service = CreateService();
+        using var events = service.OnEvent.ToLiveList();
+
+        service.NotifyDialogue(TextSource.AddonTalk);
+
+        talk.Setup(x => x.IsVisible()).Returns(false);
+        condition.Setup(c => c[ConditionFlag.WatchingCutscene78]).Returns(true);
+
+        for (var i = 0; i < 100; i++)
+            AdvanceFrame();
+
+        Assert.Single(events);
+    }
+
+    [Fact]
+    public void QuestEventCondition_BridgesLongPause()
+    {
+        using var service = CreateService();
+        using var events = service.OnEvent.ToLiveList();
+
+        service.NotifyDialogue(TextSource.AddonTalk);
+
+        talk.Setup(x => x.IsVisible()).Returns(false);
+        condition.Setup(c => c[ConditionFlag.OccupiedInQuestEvent]).Returns(true);
+
+        for (var i = 0; i < 100; i++)
+            AdvanceFrame();
+
+        Assert.Single(events);
+    }
+
+    [Fact]
+    public void BroadCondition_DoesNotStartSession()
+    {
+        using var service = CreateService();
+        using var events = service.OnEvent.ToLiveList();
+
+        condition.Setup(c => c[ConditionFlag.WatchingCutscene]).Returns(true);
+
+        for (var i = 0; i < 10; i++)
+            AdvanceFrame();
+
+        Assert.Empty(events);
+    }
+
+    // ---------------------------------------------------------------
+    // Session end
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void SessionEnds_AfterContinuationSignalsClear()
+    {
+        using var service = CreateService();
+        using var events = service.OnEvent.ToLiveList();
+
+        service.NotifyDialogue(TextSource.AddonTalk);
+
+        AdvanceFrame();
+        AdvanceFrame();
+        AdvanceFrame();
+
+        Assert.Equal(2, events.Count);
+        var ended = Assert.IsType<NpcDialogueSessionEndedEvent>(events[1]);
+        Assert.Equal(DialogueEventReason.DialogueContextEnded, ended.Reason);
+    }
+
+    [Fact]
+    public void TransientGap_DoesNotEndSession()
+    {
+        using var service = CreateService();
+        using var events = service.OnEvent.ToLiveList();
+
+        service.NotifyDialogue(TextSource.AddonTalk);
+
+        // Two frames without context (below the threshold of 3)
+        AdvanceFrame();
+        AdvanceFrame();
+
+        // Context returns
+        talk.Setup(x => x.IsVisible()).Returns(true);
+        AdvanceFrame();
+
+        // Stay alive for many more frames
+        for (var i = 0; i < 10; i++)
+            AdvanceFrame();
+
+        Assert.Single(events);
+    }
+
+    [Fact]
+    public void ReturningContext_CancelsPendingEnd()
+    {
+        using var service = CreateService();
+        using var events = service.OnEvent.ToLiveList();
+
+        service.NotifyDialogue(TextSource.AddonTalk);
+
+        // Two frames without context (below the threshold)
+        AdvanceFrame();
+        AdvanceFrame();
+
+        // Selection dialog opens, resetting the counter
+        selectString.Setup(x => x.IsVisible()).Returns(true);
+        AdvanceFrame();
+
+        // Keep alive for many more frames
+        for (var i = 0; i < 10; i++)
+            AdvanceFrame();
+
+        Assert.Single(events);
+    }
+
+    [Fact]
+    public void EndEvent_FiresOnlyOnce()
+    {
+        using var service = CreateService();
+        using var events = service.OnEvent.ToLiveList();
+
+        service.NotifyDialogue(TextSource.AddonTalk);
+
+        AdvanceFrame();
+        AdvanceFrame();
+        AdvanceFrame();
+
+        // Many more inactive frames
+        for (var i = 0; i < 10; i++)
+            AdvanceFrame();
+
+        Assert.Equal(2, events.Count);
+    }
+
+    // ---------------------------------------------------------------
+    // Hard boundaries
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void TerritoryChange_ForceEndsSession()
+    {
+        using var service = CreateService();
+        using var events = service.OnEvent.ToLiveList();
+
+        service.NotifyDialogue(TextSource.AddonTalk);
+        clientState.Raise(c => c.TerritoryChanged += null, 0u);
+
+        Assert.Equal(2, events.Count);
+        var ended = Assert.IsType<NpcDialogueSessionEndedEvent>(events[1]);
+        Assert.Equal(DialogueEventReason.TerritoryChanged, ended.Reason);
+    }
+
+    [Fact]
+    public void Logout_ForceEndsSession()
+    {
+        using var service = CreateService();
+        using var events = service.OnEvent.ToLiveList();
+
+        service.NotifyDialogue(TextSource.AddonTalk);
+        clientState.Raise(c => c.Logout += null, 0, 0);
+
+        Assert.Equal(2, events.Count);
+        var ended = Assert.IsType<NpcDialogueSessionEndedEvent>(events[1]);
+        Assert.Equal(DialogueEventReason.LoggedOut, ended.Reason);
+    }
+
+    [Fact]
+    public void Dispose_EmitsEndEvent()
+    {
+        var collected = new List<NpcDialogueSessionEvent>();
+        var service = CreateService();
+        using var sub = service.OnEvent.Subscribe(collected.Add);
+        service.NotifyDialogue(TextSource.AddonTalk);
+        service.Dispose();
+
+        Assert.Equal(2, collected.Count);
+        var ended = Assert.IsType<NpcDialogueSessionEndedEvent>(collected[1]);
+        Assert.Equal(DialogueEventReason.PluginStopped, ended.Reason);
+    }
+
+    [Fact]
+    public void TerritoryChange_WhileInactive_EmitsNothing()
+    {
+        using var service = CreateService();
+        using var events = service.OnEvent.ToLiveList();
+
+        clientState.Raise(c => c.TerritoryChanged += null, 0u);
+
+        Assert.Empty(events);
+    }
+
+    [Fact]
+    public void Logout_WhileInactive_EmitsNothing()
+    {
+        using var service = CreateService();
+        using var events = service.OnEvent.ToLiveList();
+
+        clientState.Raise(c => c.Logout += null, 0, 0);
+
+        Assert.Empty(events);
+    }
+
+    [Fact]
+    public void Dispose_WhileInactive_EmitsNothing()
+    {
+        var collected = new List<NpcDialogueSessionEvent>();
+        var service = CreateService();
+        using var sub = service.OnEvent.Subscribe(collected.Add);
+        service.Dispose();
+
+        Assert.Empty(collected);
+    }
+
+    // ---------------------------------------------------------------
+    // Event payloads
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void StartEvent_HasExpectedShape()
+    {
+        using var service = CreateService();
+        using var events = service.OnEvent.ToLiveList();
+
+        service.NotifyDialogue(TextSource.AddonTalk);
+
+        var started = Assert.IsType<NpcDialogueSessionStartedEvent>(events[0]);
+        Assert.Equal(IpcEventType.NpcDialogueSessionStarted, started.EventType);
+        Assert.Equal(TextSource.AddonTalk, started.Source);
+        Assert.Equal(DialogueEventReason.TextReceived, started.Reason);
+        Assert.NotEqual(Guid.Empty, started.SessionId);
+    }
+
+    [Fact]
+    public void EndEvent_HasExpectedShape()
+    {
+        using var service = CreateService();
+        using var events = service.OnEvent.ToLiveList();
+
+        service.NotifyDialogue(TextSource.AddonTalk);
+        var sessionId = ((NpcDialogueSessionStartedEvent)events[0]).SessionId;
+
+        AdvanceFrame();
+        AdvanceFrame();
+        AdvanceFrame();
+
+        var ended = Assert.IsType<NpcDialogueSessionEndedEvent>(events[1]);
+        Assert.Equal(IpcEventType.NpcDialogueSessionEnded, ended.EventType);
+        Assert.Equal(TextSource.AddonTalk, ended.Source);
+        Assert.Equal(DialogueEventReason.DialogueContextEnded, ended.Reason);
+        Assert.Equal(sessionId, ended.SessionId);
+    }
+
+    [Fact]
+    public void BattleTalkSession_PreservesSourceThroughEnd()
+    {
+        using var service = CreateService();
+        using var events = service.OnEvent.ToLiveList();
+
+        service.NotifyDialogue(TextSource.AddonBattleTalk);
+        var started = Assert.IsType<NpcDialogueSessionStartedEvent>(events[0]);
+        Assert.Equal(TextSource.AddonBattleTalk, started.Source);
+
+        AdvanceFrame();
+        AdvanceFrame();
+        AdvanceFrame();
+
+        var ended = Assert.IsType<NpcDialogueSessionEndedEvent>(events[1]);
+        Assert.Equal(TextSource.AddonBattleTalk, ended.Source);
+        Assert.Equal(started.SessionId, ended.SessionId);
+    }
+
+    [Fact]
+    public void BattleTalkVisibility_PreservesSourceThroughEnd()
+    {
+        using var service = CreateService();
+        using var events = service.OnEvent.ToLiveList();
+
+        battleTalk.Setup(x => x.IsVisible()).Returns(true);
+        AdvanceFrame();
+        var started = Assert.IsType<NpcDialogueSessionStartedEvent>(events[0]);
+        Assert.Equal(TextSource.AddonBattleTalk, started.Source);
+
+        battleTalk.Setup(x => x.IsVisible()).Returns(false);
+        AdvanceFrame();
+        AdvanceFrame();
+        AdvanceFrame();
+
+        var ended = Assert.IsType<NpcDialogueSessionEndedEvent>(events[1]);
+        Assert.Equal(TextSource.AddonBattleTalk, ended.Source);
+    }
+
+    // ---------------------------------------------------------------
+    // Acceptance test
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void FullCutsceneConversation()
+    {
+        using var service = CreateService();
+        using var events = service.OnEvent.ToLiveList();
+
+        // NPC line starts session
+        service.NotifyDialogue(TextSource.AddonTalk);
+        Assert.Single(events);
+        Assert.Equal(TextSource.AddonTalk, ((NpcDialogueSessionStartedEvent)events[0]).Source);
+
+        // Talk closes but cutscene remains active for many frames
+        talk.Setup(x => x.IsVisible()).Returns(false);
+        condition.Setup(c => c[ConditionFlag.WatchingCutscene]).Returns(true);
+        for (var i = 0; i < 100; i++)
+            AdvanceFrame();
+        Assert.Single(events);
+
+        // Talk reopens, another line arrives
+        talk.Setup(x => x.IsVisible()).Returns(true);
+        AdvanceFrame();
+        service.NotifyDialogue(TextSource.AddonTalk);
+        Assert.Single(events);
+
+        // Cutscene ends, all UI closes
+        talk.Setup(x => x.IsVisible()).Returns(false);
+        condition.Setup(c => c[ConditionFlag.WatchingCutscene]).Returns(false);
+        AdvanceFrame();
+        AdvanceFrame();
+        AdvanceFrame();
+
+        Assert.Equal(2, events.Count);
+        Assert.IsType<NpcDialogueSessionStartedEvent>(events[0]);
+        Assert.IsType<NpcDialogueSessionEndedEvent>(events[1]);
+
+        // Same session ID across start and end
+        var started = (NpcDialogueSessionStartedEvent)events[0];
+        var ended = (NpcDialogueSessionEndedEvent)events[1];
+        Assert.Equal(started.SessionId, ended.SessionId);
+        Assert.Equal(started.Source, ended.Source);
+    }
+}

--- a/src/TextToTalk/Backends/Megaphone/MegaphoneBackend.cs
+++ b/src/TextToTalk/Backends/Megaphone/MegaphoneBackend.cs
@@ -5,6 +5,7 @@ using System.Net.Sockets;
 using System.Numerics;
 using Dalamud.Interface.Utility.Raii;
 using TextToTalk.Backends.Websocket;
+using TextToTalk.Events;
 using TextToTalk.Services;
 using TextToTalk.UI;
 
@@ -85,6 +86,29 @@ public class MegaphoneBackend : VoiceBackend
     public override void CancelSay(TextSource source)
     {
         this.wsServer.Cancel(source);
+    }
+
+    public override void OnNpcDialogueSessionEvent(NpcDialogueSessionEvent ev)
+    {
+        try
+        {
+            var ipcMsg = MapEventToIpcMessage(ev);
+            this.wsServer.Broadcast(ipcMsg);
+        }
+        catch (Exception e)
+        {
+            DetailedLog.Error(e, "Failed to send NPC dialogue session event over Megaphone.");
+        }
+    }
+
+    private static IpcMessage MapEventToIpcMessage(NpcDialogueSessionEvent ev)
+    {
+        return new IpcMessage(IpcMessageType.Event, ev.Source)
+        {
+            EventType = ev.EventType,
+            EventSessionId = ev.SessionId,
+            EventReason = ev.Reason,
+        };
     }
 
     public override void DrawSettings(IConfigUIDelegates helpers)

--- a/src/TextToTalk/Backends/VoiceBackend.cs
+++ b/src/TextToTalk/Backends/VoiceBackend.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Numerics;
+using TextToTalk.Events;
 
 namespace TextToTalk.Backends
 {
@@ -24,6 +25,10 @@ namespace TextToTalk.Backends
         }
 
         public virtual void Stop()
+        {
+        }
+
+        public virtual void OnNpcDialogueSessionEvent(NpcDialogueSessionEvent ev)
         {
         }
 

--- a/src/TextToTalk/Backends/VoiceBackendManager.cs
+++ b/src/TextToTalk/Backends/VoiceBackendManager.cs
@@ -6,6 +6,7 @@ using System.Numerics;
 using System.Threading.Tasks;
 using TextToTalk.Backends.Azure;
 using TextToTalk.Backends.ElevenLabs;
+using TextToTalk.Backends.FishAudio;
 using TextToTalk.Backends.GoogleCloud;
 using TextToTalk.Backends.Kokoro;
 using TextToTalk.Backends.Megaphone;
@@ -14,7 +15,7 @@ using TextToTalk.Backends.Polly;
 using TextToTalk.Backends.System;
 using TextToTalk.Backends.Uberduck;
 using TextToTalk.Backends.Websocket;
-using TextToTalk.Backends.FishAudio;
+using TextToTalk.Events;
 using TextToTalk.Services;
 
 namespace TextToTalk.Backends
@@ -69,6 +70,11 @@ namespace TextToTalk.Backends
         public override TextSource GetCurrentlySpokenTextSource()
         {
             return Backend?.GetCurrentlySpokenTextSource() ?? TextSource.None;
+        }
+
+        public override void OnNpcDialogueSessionEvent(NpcDialogueSessionEvent ev)
+        {
+            Backend?.OnNpcDialogueSessionEvent(ev);
         }
 
         public void SetBackend(TTSBackend backendKind)

--- a/src/TextToTalk/Backends/Websocket/IpcEventType.cs
+++ b/src/TextToTalk/Backends/Websocket/IpcEventType.cs
@@ -1,0 +1,11 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace TextToTalk.Backends.Websocket;
+
+[JsonConverter(typeof(StringEnumConverter))]
+public enum IpcEventType
+{
+    NpcDialogueSessionStarted,
+    NpcDialogueSessionEnded,
+}

--- a/src/TextToTalk/Backends/Websocket/IpcMessage.cs
+++ b/src/TextToTalk/Backends/Websocket/IpcMessage.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Dalamud;
 using Dalamud.Game.Text;
+using TextToTalk.Events;
 using TextToTalk.GameEnums;
 
 namespace TextToTalk.Backends.Websocket;
@@ -86,13 +87,29 @@ public class IpcMessage(IpcMessageType type, TextSource source) : IEquatable<Ipc
     /// </summary>
     public float Volume { get; init; }
 
+    /// <summary>
+    /// The NPC dialogue session event type, for event messages.
+    /// </summary>
+    public IpcEventType? EventType { get; init; }
+
+    /// <summary>
+    /// The unique session ID, for event messages.
+    /// </summary>
+    public Guid? EventSessionId { get; init; }
+
+    /// <summary>
+    /// The reason for the session event, for event messages.
+    /// </summary>
+    public DialogueEventReason? EventReason { get; init; }
+
     public bool Equals(IpcMessage? other)
     {
         if (ReferenceEquals(null, other)) return false;
         if (ReferenceEquals(this, other)) return true;
         return Speaker == other.Speaker && Type == other.Type && Payload == other.Payload &&
                Equals(Voice, other.Voice) && StuttersRemoved == other.StuttersRemoved && Source == other.Source &&
-               NpcId == other.NpcId && ChatType == other.ChatType && Volume.Equals(other.Volume);
+               NpcId == other.NpcId && ChatType == other.ChatType && Volume.Equals(other.Volume) &&
+               EventType == other.EventType && EventSessionId == other.EventSessionId && EventReason == other.EventReason;
     }
 
     public override bool Equals(object? obj)
@@ -106,6 +123,6 @@ public class IpcMessage(IpcMessageType type, TextSource source) : IEquatable<Ipc
     {
         return HashCode.Combine(
             HashCode.Combine(Speaker, Type, Payload, Voice, StuttersRemoved, Source, NpcId, ChatType),
-            Volume);
+            HashCode.Combine(EventType, EventSessionId, EventReason, Volume));
     }
 }

--- a/src/TextToTalk/Backends/Websocket/IpcMessageType.cs
+++ b/src/TextToTalk/Backends/Websocket/IpcMessageType.cs
@@ -4,4 +4,5 @@ public enum IpcMessageType
 {
     Say,
     Cancel,
+    Event,
 }

--- a/src/TextToTalk/Backends/Websocket/WSServer.cs
+++ b/src/TextToTalk/Backends/Websocket/WSServer.cs
@@ -67,6 +67,16 @@ public class WSServer : IDisposable
         }
     }
 
+    public void Broadcast(IpcMessage message)
+    {
+        if (!Active) throw new InvalidOperationException("Server is not active!");
+
+        foreach (var behavior in this.behaviors)
+        {
+            behavior.SendMessage(JsonConvert.SerializeObject(message));
+        }
+    }
+
     public void CancelAll() => Cancel(TextSource.None);
 
     public void Cancel(TextSource source)

--- a/src/TextToTalk/Backends/Websocket/WebsocketBackend.cs
+++ b/src/TextToTalk/Backends/Websocket/WebsocketBackend.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Numerics;
 using Dalamud.Interface.Utility.Raii;
+using TextToTalk.Events;
 using TextToTalk.Services;
 using TextToTalk.UI;
 
@@ -82,6 +83,29 @@ public class WebsocketBackend : VoiceBackend
     public override void CancelSay(TextSource source)
     {
         this.wsServer.Cancel(source);
+    }
+
+    public override void OnNpcDialogueSessionEvent(NpcDialogueSessionEvent ev)
+    {
+        try
+        {
+            var ipcMsg = MapEventToIpcMessage(ev);
+            this.wsServer.Broadcast(ipcMsg);
+        }
+        catch (Exception e)
+        {
+            DetailedLog.Error(e, "Failed to send NPC dialogue session event over Websocket.");
+        }
+    }
+
+    private static IpcMessage MapEventToIpcMessage(NpcDialogueSessionEvent ev)
+    {
+        return new IpcMessage(IpcMessageType.Event, ev.Source)
+        {
+            EventType = ev.EventType,
+            EventSessionId = ev.SessionId,
+            EventReason = ev.Reason,
+        };
     }
 
     public override void DrawSettings(IConfigUIDelegates helpers)

--- a/src/TextToTalk/Events/DialogueEventReason.cs
+++ b/src/TextToTalk/Events/DialogueEventReason.cs
@@ -1,0 +1,11 @@
+namespace TextToTalk.Events;
+
+public enum DialogueEventReason
+{
+    TextReceived,
+    AddonShown,
+    DialogueContextEnded,
+    TerritoryChanged,
+    LoggedOut,
+    PluginStopped,
+}

--- a/src/TextToTalk/Events/NpcDialogueSessionEndedEvent.cs
+++ b/src/TextToTalk/Events/NpcDialogueSessionEndedEvent.cs
@@ -1,0 +1,8 @@
+using TextToTalk.Backends.Websocket;
+
+namespace TextToTalk.Events;
+
+public class NpcDialogueSessionEndedEvent(TextSource source) : NpcDialogueSessionEvent(source)
+{
+    public override IpcEventType EventType => IpcEventType.NpcDialogueSessionEnded;
+}

--- a/src/TextToTalk/Events/NpcDialogueSessionEvent.cs
+++ b/src/TextToTalk/Events/NpcDialogueSessionEvent.cs
@@ -1,0 +1,15 @@
+using System;
+using TextToTalk.Backends.Websocket;
+
+namespace TextToTalk.Events;
+
+public abstract class NpcDialogueSessionEvent(TextSource source)
+{
+    public abstract IpcEventType EventType { get; }
+
+    public Guid SessionId { get; init; }
+
+    public TextSource Source { get; } = source;
+
+    public DialogueEventReason Reason { get; init; }
+}

--- a/src/TextToTalk/Events/NpcDialogueSessionStartedEvent.cs
+++ b/src/TextToTalk/Events/NpcDialogueSessionStartedEvent.cs
@@ -1,0 +1,8 @@
+using TextToTalk.Backends.Websocket;
+
+namespace TextToTalk.Events;
+
+public class NpcDialogueSessionStartedEvent(TextSource source) : NpcDialogueSessionEvent(source)
+{
+    public override IpcEventType EventType => IpcEventType.NpcDialogueSessionStarted;
+}

--- a/src/TextToTalk/Services/DialogueSessionService.cs
+++ b/src/TextToTalk/Services/DialogueSessionService.cs
@@ -1,0 +1,179 @@
+using Dalamud.Game.ClientState.Conditions;
+using Dalamud.Plugin.Services;
+using R3;
+using System;
+using TextToTalk.Events;
+using TextToTalk.Talk;
+
+namespace TextToTalk.Services;
+
+// Sessions are intentionally conservative.
+//
+// Dialogue-specific signals start sessions.
+// Broader game state may only extend them.
+//
+// This avoids false positives from unrelated quest/cutscene state.
+
+public enum DialogueSessionState
+{
+    Inactive,
+    Active,
+}
+
+public class DialogueSessionService : IDisposable
+{
+    private const int EndDelayFrames = 3;
+
+    private readonly IFramework framework;
+    private readonly IClientState clientState;
+    private readonly ICondition condition;
+    private readonly IAddonSelectStringManager addonSelectStringManager;
+    private readonly IAddonSelectIconStringManager addonSelectIconStringManager;
+    private readonly IAddonTalkManager addonTalkManager;
+    private readonly IAddonBattleTalkManager addonBattleTalkManager;
+
+    private DialogueSessionState state = DialogueSessionState.Inactive;
+    private int inactiveFrames;
+    private Guid sessionId;
+    private TextSource sessionSource = TextSource.None;
+
+    private bool prevTalkVisible;
+    private bool prevBattleTalkVisible;
+
+    private readonly Subject<NpcDialogueSessionEvent> onEvent = new();
+
+    public Observable<NpcDialogueSessionEvent> OnEvent => onEvent;
+
+    public DialogueSessionService(IFramework framework, IClientState clientState, ICondition condition,
+        IAddonSelectStringManager addonSelectStringManager, IAddonSelectIconStringManager addonSelectIconStringManager,
+        IAddonTalkManager addonTalkManager, IAddonBattleTalkManager addonBattleTalkManager)
+    {
+        this.framework = framework;
+        this.clientState = clientState;
+        this.condition = condition;
+        this.addonSelectStringManager = addonSelectStringManager;
+        this.addonSelectIconStringManager = addonSelectIconStringManager;
+        this.addonTalkManager = addonTalkManager;
+        this.addonBattleTalkManager = addonBattleTalkManager;
+
+        this.framework.Update += OnFrameworkUpdate;
+        this.clientState.TerritoryChanged += OnTerritoryChanged;
+        this.clientState.Logout += OnLogout;
+    }
+
+    public void NotifyDialogue(TextSource source)
+    {
+        if (source is not (TextSource.AddonTalk or TextSource.AddonBattleTalk))
+            return;
+
+        this.framework.Run(() =>
+        {
+            if (state == DialogueSessionState.Inactive)
+            {
+                StartSession(source, DialogueEventReason.TextReceived);
+            }
+
+            ResetInactiveFrames();
+        });
+    }
+
+    private void OnFrameworkUpdate(IFramework _)
+    {
+        var talkVisible = addonTalkManager.IsVisible();
+        var battleTalkVisible = addonBattleTalkManager.IsVisible();
+
+        if (talkVisible && !prevTalkVisible)
+            OnDialogueAddonShown(TextSource.AddonTalk);
+        if (battleTalkVisible && !prevBattleTalkVisible)
+            OnDialogueAddonShown(TextSource.AddonBattleTalk);
+
+        prevTalkVisible = talkVisible;
+        prevBattleTalkVisible = battleTalkVisible;
+
+        if (state == DialogueSessionState.Inactive)
+            return;
+
+        if (HasContinuationContext(talkVisible, battleTalkVisible))
+        {
+            ResetInactiveFrames();
+            return;
+        }
+
+        if (++inactiveFrames >= EndDelayFrames)
+        {
+            EndSession(DialogueEventReason.DialogueContextEnded);
+        }
+    }
+
+    private bool HasContinuationContext(bool talkVisible, bool battleTalkVisible)
+    {
+        return talkVisible ||
+               battleTalkVisible ||
+               addonSelectStringManager.IsVisible() ||
+               addonSelectIconStringManager.IsVisible() ||
+               condition[ConditionFlag.WatchingCutscene] ||
+               condition[ConditionFlag.WatchingCutscene78] ||
+               condition[ConditionFlag.OccupiedInQuestEvent];
+    }
+
+    private void OnDialogueAddonShown(TextSource source)
+    {
+        if (state == DialogueSessionState.Inactive)
+        {
+            StartSession(source, DialogueEventReason.AddonShown);
+        }
+
+        ResetInactiveFrames();
+    }
+
+    private void StartSession(TextSource source, DialogueEventReason reason)
+    {
+        state = DialogueSessionState.Active;
+        sessionId = Guid.NewGuid();
+        sessionSource = source;
+        inactiveFrames = 0;
+
+        onEvent.OnNext(new NpcDialogueSessionStartedEvent(source)
+        {
+            SessionId = sessionId,
+            Reason = reason,
+        });
+    }
+
+    private void ResetInactiveFrames()
+    {
+        inactiveFrames = 0;
+    }
+
+    private void EndSession(DialogueEventReason reason)
+    {
+        if (state == DialogueSessionState.Inactive)
+            return;
+
+        onEvent.OnNext(new NpcDialogueSessionEndedEvent(sessionSource)
+        {
+            SessionId = sessionId,
+            Reason = reason,
+        });
+
+        state = DialogueSessionState.Inactive;
+        sessionId = Guid.Empty;
+        sessionSource = TextSource.None;
+        inactiveFrames = 0;
+    }
+
+    private void OnTerritoryChanged(uint _) => EndSession(DialogueEventReason.TerritoryChanged);
+
+    private void OnLogout(int type, int code) => EndSession(DialogueEventReason.LoggedOut);
+
+    public void Dispose()
+    {
+        EndSession(DialogueEventReason.PluginStopped);
+
+        this.clientState.Logout -= OnLogout;
+        this.clientState.TerritoryChanged -= OnTerritoryChanged;
+        this.framework.Update -= OnFrameworkUpdate;
+
+        onEvent.Dispose();
+    }
+}

--- a/src/TextToTalk/Talk/AddonBattleTalkManager.cs
+++ b/src/TextToTalk/Talk/AddonBattleTalkManager.cs
@@ -3,7 +3,7 @@ using TextToTalk.Utils;
 
 namespace TextToTalk.Talk;
 
-public class AddonBattleTalkManager : AddonManager
+public class AddonBattleTalkManager : AddonManager, IAddonBattleTalkManager
 {
     public AddonBattleTalkManager(IFramework framework, IClientState clientState, ICondition condition, IGameGui gui) :
         base(framework, clientState, condition, gui, "_BattleTalk")

--- a/src/TextToTalk/Talk/AddonSelectIconStringManager.cs
+++ b/src/TextToTalk/Talk/AddonSelectIconStringManager.cs
@@ -1,0 +1,24 @@
+using Dalamud.Plugin.Services;
+using FFXIVClientStructs.FFXIV.Client.UI;
+using TextToTalk.Utils;
+
+namespace TextToTalk.Talk;
+
+public class AddonSelectIconStringManager : AddonManager, IAddonSelectIconStringManager
+{
+    public AddonSelectIconStringManager(IFramework framework, IClientState clientState, ICondition condition, IGameGui gui) : base(
+        framework, clientState, condition, gui, "SelectIconString")
+    {
+    }
+
+    public unsafe bool IsVisible()
+    {
+        var addon = GetAddonSelectIconString();
+        return addon != null && addon->AtkUnitBase.IsVisible;
+    }
+
+    private unsafe AddonSelectIconString* GetAddonSelectIconString()
+    {
+        return (AddonSelectIconString*)Address.ToPointer();
+    }
+}

--- a/src/TextToTalk/Talk/AddonSelectStringManager.cs
+++ b/src/TextToTalk/Talk/AddonSelectStringManager.cs
@@ -1,0 +1,24 @@
+using Dalamud.Plugin.Services;
+using FFXIVClientStructs.FFXIV.Client.UI;
+using TextToTalk.Utils;
+
+namespace TextToTalk.Talk;
+
+public class AddonSelectStringManager : AddonManager, IAddonSelectStringManager
+{
+    public AddonSelectStringManager(IFramework framework, IClientState clientState, ICondition condition, IGameGui gui) : base(
+        framework, clientState, condition, gui, "SelectString")
+    {
+    }
+
+    public unsafe bool IsVisible()
+    {
+        var addon = GetAddonSelectString();
+        return addon != null && addon->AtkUnitBase.IsVisible;
+    }
+
+    private unsafe AddonSelectString* GetAddonSelectString()
+    {
+        return (AddonSelectString*)Address.ToPointer();
+    }
+}

--- a/src/TextToTalk/Talk/AddonTalkManager.cs
+++ b/src/TextToTalk/Talk/AddonTalkManager.cs
@@ -4,7 +4,7 @@ using TextToTalk.Utils;
 
 namespace TextToTalk.Talk;
 
-public class AddonTalkManager : AddonManager
+public class AddonTalkManager : AddonManager, IAddonTalkManager
 {
     public AddonTalkManager(IFramework framework, IClientState clientState, ICondition condition, IGameGui gui) : base(
         framework, clientState, condition, gui, "Talk")

--- a/src/TextToTalk/Talk/IAddonBattleTalkManager.cs
+++ b/src/TextToTalk/Talk/IAddonBattleTalkManager.cs
@@ -1,0 +1,6 @@
+namespace TextToTalk.Talk;
+
+public interface IAddonBattleTalkManager
+{
+    bool IsVisible();
+}

--- a/src/TextToTalk/Talk/IAddonSelectIconStringManager.cs
+++ b/src/TextToTalk/Talk/IAddonSelectIconStringManager.cs
@@ -1,0 +1,6 @@
+namespace TextToTalk.Talk;
+
+public interface IAddonSelectIconStringManager
+{
+    bool IsVisible();
+}

--- a/src/TextToTalk/Talk/IAddonSelectStringManager.cs
+++ b/src/TextToTalk/Talk/IAddonSelectStringManager.cs
@@ -1,0 +1,6 @@
+namespace TextToTalk.Talk;
+
+public interface IAddonSelectStringManager
+{
+    bool IsVisible();
+}

--- a/src/TextToTalk/Talk/IAddonTalkManager.cs
+++ b/src/TextToTalk/Talk/IAddonTalkManager.cs
@@ -1,0 +1,6 @@
+namespace TextToTalk.Talk;
+
+public interface IAddonTalkManager
+{
+    bool IsVisible();
+}

--- a/src/TextToTalk/TextToTalk.cs
+++ b/src/TextToTalk/TextToTalk.cs
@@ -78,6 +78,7 @@ private readonly IDalamudPluginInterface pluginInterface;
         private readonly ILiteDatabase database;
         private readonly PlayerService playerService;
         private readonly NpcService npcService;
+        private readonly DialogueSessionService dialogueSessionService;
         private readonly WindowSystem windows;
         private readonly IDataManager data;
         private readonly NotificationService notificationService;
@@ -139,6 +140,8 @@ private readonly IDalamudPluginInterface pluginInterface;
 
             this.addonTalkManager = new AddonTalkManager(framework, clientState, condition, gui);
             this.addonBattleTalkManager = new AddonBattleTalkManager(framework, clientState, condition, gui);
+            var addonSelectStringManager = new AddonSelectStringManager(framework, clientState, condition, gui);
+            var addonSelectIconStringManager = new AddonSelectIconStringManager(framework, clientState, condition, gui);
             this.configUIDelegates = new ConfigUIDelegates();
             
 
@@ -185,6 +188,10 @@ private readonly IDalamudPluginInterface pluginInterface;
             this.soundHandler =
                 new SoundHandler(this.addonTalkHandler, this.addonBattleTalkHandler, sigScanner, gameInterop);
 
+            this.dialogueSessionService = new DialogueSessionService(framework, clientState, condition,
+                addonSelectStringManager, addonSelectIconStringManager,
+                this.addonTalkManager, this.addonBattleTalkManager);
+
             this.rateLimiter = new ConfiguredRateLimiter(this.config);
 
             this.ungenderedOverrides = new UngenderedOverrideManager();
@@ -199,10 +206,13 @@ private readonly IDalamudPluginInterface pluginInterface;
 
             var handleTextCancel = HandleTextCancel();
             var handleTextEmit = HandleTextEmit();
-
+            var handleDialogueSessions = this.dialogueSessionService.OnEvent
+                .Subscribe(ev => FunctionalUtils.RunSafely(
+                    () => this.backendManager.OnNpcDialogueSessionEvent(ev),
+                    ex => DetailedLog.Error(ex, "Failed to handle dialogue session event")));
 
             this.unsubscribeAll = Disposable.Combine(handleTextCancel, handleTextEmit, handleUnlockerResult,
-                handlePresetOpenRequested);
+                handlePresetOpenRequested, handleDialogueSessions);
         }
 
 
@@ -245,7 +255,11 @@ private readonly IDalamudPluginInterface pluginInterface;
                 .SubscribeOnThreadPool()
                 .Subscribe(
                     ev => FunctionalUtils.RunSafely(
-                        () => Say(ev.Speaker, ev.SpeakerName, ev.GetChatType(), ev.Text.TextValue, ev.Source),
+                        () =>
+                        {
+                            Say(ev.Speaker, ev.SpeakerName, ev.GetChatType(), ev.Text.TextValue, ev.Source);
+                            this.dialogueSessionService.NotifyDialogue(ev.Source);
+                        },
                         ex => DetailedLog.Error(ex, "Failed to handle text emit event")),
                     ex => DetailedLog.Error(ex, "Text emit event sequence has faulted"),
                     _ => { });
@@ -597,6 +611,8 @@ private readonly IDalamudPluginInterface pluginInterface;
             this.commandModule.Dispose();
 
             this.soundHandler.Dispose();
+
+            this.dialogueSessionService.Dispose();
 
             this.configurationWindow.Dispose();
 


### PR DESCRIPTION
## Why

External tools need to know when an NPC conversation starts and ends. This will assist with various "modal" states, where perhaps we want to treat audio differently when it comes from chat than from dialogue / cinematics.

Specifically, I was having a conversation with a user of Megaphone who was asking questions about how to make the non-npc audio more user friendly in my app. And I think the answer is that I want to queue up audio from the chat window, and play it FIFO, but NPC dialogue should follow the say-and-cancel path. These events will allow me to detect that modality.

## How it works

A new `DialogueSessionService` watches game state and emits events over the existing IPC channel:

Starting a session
- NPC / Battle dialogue text arrives
- Talk or BattleTalk addon becomes visible
- Emits `{ "type": "Event", "eventType": "NpcDialogueSessionStarted", "source": "AddonTalk", "reason": "TextReceived", "sessionId": "..." }`

Keeping it alive
- Dialogue, selection, or cutscene conditions remain active

Ending a session
- All signals absent for 3 consecutive frames
- Territory change, logout, or plugin shutdown force-ends immediately
- Emits `{ "type": "Event", "eventType": "NpcDialogueSessionEnded", "source": "AddonTalk", "reason": "DialogueContextEnded", "sessionId": "..." }`

Example flow:
```
NPC says line → session starts (TextReceived)
cutscene plays for 2 minutes → session stays alive
dialogue ends, no UI → 3 frames later → session ends (DialogueContextEnded)
```
