### PR TITLE
Added world id from chat event to IpcMessage

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ TTS prompt:
   "Voice": {
     "Name": "Gender"
   },
-   "Speaker": "Firstname Lastname",
-   // Speaker's home world row ID and display name, or null when unavailable.
-   "SpeakerWorld": "Cactuar",
-   // or "AddonTalk", or "AddonBattleTalk"
+  "Speaker": "Firstname Lastname",
+  // Speaker's home world display name, or null when unavailable.
+  "SpeakerWorld": "Cactuar",
+  // or "AddonTalk", or "AddonBattleTalk"
   "Source": "Chat",
   "StuttersRemoved": false,
   // or null, for non-NPCs

--- a/README.md
+++ b/README.md
@@ -44,8 +44,10 @@ TTS prompt:
   "Voice": {
     "Name": "Gender"
   },
-  "Speaker": "Firstname Lastname",
-  // or "AddonTalk", or "AddonBattleTalk"
+   "Speaker": "Firstname Lastname",
+   // Speaker's home world row ID and display name, or null when unavailable.
+   "SpeakerWorld": "Cactuar",
+   // or "AddonTalk", or "AddonBattleTalk"
   "Source": "Chat",
   "StuttersRemoved": false,
   // or null, for non-NPCs

--- a/src/TextToTalk.Tests/Backends/Websocket/WSServerTests.cs
+++ b/src/TextToTalk.Tests/Backends/Websocket/WSServerTests.cs
@@ -212,6 +212,7 @@ public class WSServerTests
             Source = source,
             Voice = preset,
             Speaker = "Speaker",
+            SpeakerWorld = "Cactuar",
             Text = "Hello, world!",
             TextTemplate = "Hello, world!",
             Race = "Hyur",
@@ -232,6 +233,8 @@ public class WSServerTests
             {
                 Voice = preset,
                 Speaker = "Speaker",
+                SpeakerWorld = "Cactuar",
+                BodyType = "Adult",
                 Payload = "Hello, world!",
                 PayloadTemplate = "Hello, world!",
                 ChatType = (int)XivChatType.Say,

--- a/src/TextToTalk.Tests/Utils/TalkUtilsTests.cs
+++ b/src/TextToTalk.Tests/Utils/TalkUtilsTests.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using Dalamud.Game.Text.SeStringHandling;
+using Dalamud.Game.Text.SeStringHandling.Payloads;
 using TextToTalk.Utils;
 using Xunit;
 
@@ -128,6 +130,14 @@ public class TalkUtilsTests
         });
 
         Assert.Equal("This TOKEN3.", actual);
+    }
+
+    [Fact]
+    public void GetPlayerWorldName_WithoutPlayerPayload_ReturnsNull()
+    {
+        var actual = TalkUtils.GetPlayerWorldName(new SeStringBuilder().AddText("Speaker").Build());
+
+        Assert.Null(actual);
     }
 
     private static void TestRemoveStutters(string input, string expected)

--- a/src/TextToTalk/Backends/SayRequest.cs
+++ b/src/TextToTalk/Backends/SayRequest.cs
@@ -25,6 +25,11 @@ public record SayRequest
     public required string Speaker { get; init; }
 
     /// <summary>
+    /// The speaker's home world name, when available.
+    /// </summary>
+    public string? SpeakerWorld { get; init; }
+
+    /// <summary>
     /// The speaker's data ID, in the case of NPCs. For most NPCs, their name can
     /// be retrieved from the ENpcResident table, if needed.
     /// </summary>

--- a/src/TextToTalk/Backends/Websocket/IpcMessage.cs
+++ b/src/TextToTalk/Backends/Websocket/IpcMessage.cs
@@ -20,6 +20,11 @@ public class IpcMessage(IpcMessageType type, TextSource source) : IEquatable<Ipc
     public string? Speaker { get; init; }
 
     /// <summary>
+    /// The speaker's home world name, when available.
+    /// </summary>
+    public string? SpeakerWorld { get; init; }
+
+    /// <summary>
     /// The speaker's data ID, in the case of NPCs. For most NPCs, their name can
     /// be retrieved from the ENpcResident table, if needed.
     /// </summary>
@@ -106,7 +111,7 @@ public class IpcMessage(IpcMessageType type, TextSource source) : IEquatable<Ipc
     {
         if (ReferenceEquals(null, other)) return false;
         if (ReferenceEquals(this, other)) return true;
-        return Speaker == other.Speaker && Type == other.Type && Payload == other.Payload &&
+        return Speaker == other.Speaker && SpeakerWorld == other.SpeakerWorld && Type == other.Type && Payload == other.Payload &&
                Equals(Voice, other.Voice) && StuttersRemoved == other.StuttersRemoved && Source == other.Source &&
                NpcId == other.NpcId && ChatType == other.ChatType && Volume.Equals(other.Volume) &&
                EventType == other.EventType && EventSessionId == other.EventSessionId && EventReason == other.EventReason;
@@ -122,7 +127,8 @@ public class IpcMessage(IpcMessageType type, TextSource source) : IEquatable<Ipc
     public override int GetHashCode()
     {
         return HashCode.Combine(
-            HashCode.Combine(Speaker, Type, Payload, Voice, StuttersRemoved, Source, NpcId, ChatType),
+            HashCode.Combine(Speaker, SpeakerWorld, Type, Payload),
+            HashCode.Combine(Voice, StuttersRemoved, Source, NpcId, ChatType),
             HashCode.Combine(EventType, EventSessionId, EventReason, Volume));
     }
 }

--- a/src/TextToTalk/Events/ChatTextEmitEvent.cs
+++ b/src/TextToTalk/Events/ChatTextEmitEvent.cs
@@ -8,11 +8,17 @@ public class ChatTextEmitEvent(
     SeString speaker,
     SeString text,
     IGameObject? obj,
-    XivChatType chatType)
+    XivChatType chatType,
+    string? speakerWorld = null)
     : TextEmitEvent(TextSource.Chat, speaker, text, obj)
 {
     /// <summary>
     /// The chat type of the message.
     /// </summary>
     public XivChatType ChatType { get; } = chatType;
+
+    /// <summary>
+    /// The speaker's home world name, when available.
+    /// </summary>
+    public string? SpeakerWorld { get; } = speakerWorld;
 }

--- a/src/TextToTalk/TextProviders/ChatMessageHandler.cs
+++ b/src/TextToTalk/TextProviders/ChatMessageHandler.cs
@@ -4,6 +4,7 @@ using System.ComponentModel.Design;
 using System.Drawing.Text;
 using System.Reflection.Metadata.Ecma335;
 using Dalamud.Game.Chat;
+using Dalamud.Game.ClientState.Objects.SubKinds;
 using Dalamud.Game.ClientState.Objects.Types;
 using Dalamud.Game.Text;
 using Dalamud.Game.Text.SeStringHandling;
@@ -122,6 +123,14 @@ public class ChatMessageHandler : IChatMessageHandler
         // Find the game object this speaker represents
         var speaker = ObjectTableUtils.GetGameObjectByName(this.objects, sender);
 
+        // Player links contain the speaker's world even when the character is not
+        // present in the object table, such as cross-world linkshell messages.
+        var speakerWorld = TalkUtils.GetPlayerWorldName(sender);
+        if (speakerWorld is null && speaker is IPlayerCharacter player)
+        {
+            speakerWorld = player.HomeWorld.Value.Name.ToString();
+        }
+
         if (!this.filters.OnlyMessagesFromYou(speaker?.Name.TextValue ?? sender.TextValue)) return;
 
         if (!this.filters.ShouldSayFromYou(speaker?.Name.TextValue ?? sender.TextValue)) return;
@@ -133,7 +142,8 @@ public class ChatMessageHandler : IChatMessageHandler
             GetCleanSpeakerName(speaker, sender),
             textValue,
             speaker,
-            type));
+            type,
+            speakerWorld));
     }
 
     private static SeString GetCleanSpeakerName(IGameObject? speaker, SeString sender)

--- a/src/TextToTalk/TextToTalk.cs
+++ b/src/TextToTalk/TextToTalk.cs
@@ -257,7 +257,8 @@ private readonly IDalamudPluginInterface pluginInterface;
                     ev => FunctionalUtils.RunSafely(
                         () =>
                         {
-                            Say(ev.Speaker, ev.SpeakerName, ev.GetChatType(), ev.Text.TextValue, ev.Source);
+                            Say(ev.Speaker, ev.SpeakerName, ev.GetChatType(), ev.Text.TextValue, ev.Source,
+                                ev is ChatTextEmitEvent chatEvent ? chatEvent.SpeakerWorld : null);
                             this.dialogueSessionService.NotifyDialogue(ev.Source);
                         },
                         ex => DetailedLog.Error(ex, "Failed to handle text emit event")),
@@ -322,7 +323,7 @@ private readonly IDalamudPluginInterface pluginInterface;
         }
 
         private unsafe void Say(GameObject? speaker, SeString speakerName, XivChatType? chatType, string textValue,
-            TextSource source)
+            TextSource source, string? speakerWorld)
         {
             // Check if this speaker should be skipped
             if (speaker != null && this.rateLimiter.TryRateLimit(speaker))
@@ -380,6 +381,11 @@ private readonly IDalamudPluginInterface pluginInterface;
             // as hyphens for the sake of the plugin.
             var cleanSpeakerName = TalkUtils.NormalizePunctuation(speakerName.TextValue);
 
+            if (speakerWorld is null && speaker is IPlayerCharacter player)
+            {
+                speakerWorld = player.HomeWorld.Value.Name.ToString();
+            }
+
             // Attempt to get the speaker's ID, if they're an NPC
             var npcId = speaker?.GetNpcId();
 
@@ -409,6 +415,7 @@ private readonly IDalamudPluginInterface pluginInterface;
             {
                 Source = source,
                 Speaker = cleanSpeakerName,
+                SpeakerWorld = speakerWorld,
                 Text = cleanText,
                 Style = textStyle,
                 TextTemplate = textTemplate,

--- a/src/TextToTalk/Utils/TalkUtils.cs
+++ b/src/TextToTalk/Utils/TalkUtils.cs
@@ -156,6 +156,16 @@ namespace TextToTalk.Utils
             return playerName.TextValue;
         }
 
+        public static string? GetPlayerWorldName(SeString playerName)
+        {
+            if (playerName.Payloads.FirstOrDefault(p => p is PlayerPayload) is PlayerPayload player)
+            {
+                return player.World.Value.Name.ToString();
+            }
+
+            return null;
+        }
+
         public static string? GetPartialName(string? name, FirstOrLastName part)
         {
             if (string.IsNullOrWhiteSpace(name))


### PR DESCRIPTION
Megaphone needs reliable player race and gender data to select the appropriate voice. Speaker names alone are not sufficient to identify a player character, especially when names can be duplicated across worlds. The world name provides the additional identity needed to lookup player character details to resolve a voice.