### PR TITLE
Added ModelCharaId to say request for debugging and experimental voic…

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ TTS prompt:
   "NpcId": 1000115,
   // "Hyur", "Elezen", "Lalafell", "Miqo'te", "Roegadyn", "Au Ra", "Hrothgar", "Viera", or null
   "Race": null,
+  // The speaker's ModelChara ID, or null when unavailable/non-NPC.
+  "ModelCharaId": null,
   // "Unknown", "Youth", "Adult", "Elder", or null
   "BodyType": null,
   // "None", "Male", "Female", or null

--- a/src/TextToTalk.Tests/Backends/Websocket/WSServerTests.cs
+++ b/src/TextToTalk.Tests/Backends/Websocket/WSServerTests.cs
@@ -218,6 +218,7 @@ public class WSServerTests
             Race = "Hyur",
             BodyType = GameEnums.BodyType.Adult,
             Gender = GameEnums.Gender.None,
+            ModelCharaId = 1234,
             ChatType = XivChatType.Say,
             Language = ClientLanguage.English,
         });
@@ -234,6 +235,7 @@ public class WSServerTests
                 Voice = preset,
                 Speaker = "Speaker",
                 SpeakerWorld = "Cactuar",
+                ModelCharaId = 1234,
                 BodyType = "Adult",
                 Payload = "Hello, world!",
                 PayloadTemplate = "Hello, world!",

--- a/src/TextToTalk/Backends/SayRequest.cs
+++ b/src/TextToTalk/Backends/SayRequest.cs
@@ -36,6 +36,11 @@ public record SayRequest
     public uint? NpcId { get; init; }
 
     /// <summary>
+    /// The speaker's ModelChara ID, in the case of NPCs.
+    /// </summary>
+    public int? ModelCharaId { get; init; }
+
+    /// <summary>
     /// The speaker's race in the Race table (e.g. "Hyur", "Elezen", etc.).
     /// </summary>
     public required string Race { get; init; }

--- a/src/TextToTalk/Backends/Websocket/IpcMessage.cs
+++ b/src/TextToTalk/Backends/Websocket/IpcMessage.cs
@@ -31,6 +31,11 @@ public class IpcMessage(IpcMessageType type, TextSource source) : IEquatable<Ipc
     public long? NpcId { get; init; }
 
     /// <summary>
+    /// The speaker's ModelChara ID, in the case of NPCs.
+    /// </summary>
+    public int? ModelCharaId { get; init; }
+
+    /// <summary>
     /// The speaker's race in the Race table (e.g. "Hyur", "Elezen", etc.).
     /// </summary>
     public string? Race { get; init; }
@@ -113,7 +118,7 @@ public class IpcMessage(IpcMessageType type, TextSource source) : IEquatable<Ipc
         if (ReferenceEquals(this, other)) return true;
         return Speaker == other.Speaker && SpeakerWorld == other.SpeakerWorld && Type == other.Type && Payload == other.Payload &&
                Equals(Voice, other.Voice) && StuttersRemoved == other.StuttersRemoved && Source == other.Source &&
-               NpcId == other.NpcId && ChatType == other.ChatType && Volume.Equals(other.Volume) &&
+               NpcId == other.NpcId && ModelCharaId == other.ModelCharaId && ChatType == other.ChatType && Volume.Equals(other.Volume) &&
                EventType == other.EventType && EventSessionId == other.EventSessionId && EventReason == other.EventReason;
     }
 
@@ -128,7 +133,7 @@ public class IpcMessage(IpcMessageType type, TextSource source) : IEquatable<Ipc
     {
         return HashCode.Combine(
             HashCode.Combine(Speaker, SpeakerWorld, Type, Payload),
-            HashCode.Combine(Voice, StuttersRemoved, Source, NpcId, ChatType),
+            HashCode.Combine(Voice, StuttersRemoved, Source, NpcId, ModelCharaId, ChatType),
             HashCode.Combine(EventType, EventSessionId, EventReason, Volume));
     }
 }

--- a/src/TextToTalk/TextToTalk.cs
+++ b/src/TextToTalk/TextToTalk.cs
@@ -397,9 +397,14 @@ private readonly IDalamudPluginInterface pluginInterface;
 
             // Get the speaker's gender if it exists.
             var gender = Gender.None;
+            int? modelCharaId = null;
             if(TryGetCharacter(speaker, out var charaStruct))
             {
                 gender = (Gender)charaStruct->Sex;
+                if (npcId is not null)
+                {
+                    modelCharaId = charaStruct->ModelContainer.ModelCharaId;
+                }
             }
 
             // Get the speaker's voice preset
@@ -423,6 +428,7 @@ private readonly IDalamudPluginInterface pluginInterface;
                 ChatType = chatType,
                 Language = this.clientState.ClientLanguage,
                 NpcId = npcId,
+                ModelCharaId = modelCharaId,
                 Race = race,
                 BodyType = bodyType,
                 Gender = gender,


### PR DESCRIPTION
NPC speech consumers need the actor's model identifier to select or map experimental character-specific behavior downstream.

This adds nullable `ModelCharaId` metadata to the shared speech request and IPC payload models, populated from the active NPC's native character data. The field is forwarded through both WebSocket and Megaphone speech messages.
